### PR TITLE
Add cloud infrastructure detection to QuickDetect

### DIFF
--- a/install-requirements.sh
+++ b/install-requirements.sh
@@ -3,4 +3,5 @@ apt-get install python3 python3-pip git -y
 pip3 install pyvirtualdisplay
 pip3 install selenium
 pip3 install requests
+pip3 install ipwhois
 pip3 install --upgrade selenium

--- a/libs/quickdetect/CloudIPUtil.py
+++ b/libs/quickdetect/CloudIPUtil.py
@@ -1,0 +1,39 @@
+import socket
+from urllib.parse import urlparse
+from ipwhois import IPWhois
+
+class CloudIPUtil:
+    def __init__(self, url):
+        self.url = url
+
+    def get_provider(self):
+        parsed = urlparse(self.url)
+        domain = parsed.hostname
+        if not domain:
+            return None
+        try:
+            ip = socket.gethostbyname(domain)
+        except Exception:
+            return None
+        try:
+            obj = IPWhois(ip)
+            data = obj.lookup_rdap(depth=1)
+            text = "{} {}".format(
+                data.get('network', {}).get('name', ''),
+                data.get('asn_description', '')
+            ).lower()
+            providers = {
+                'amazon': 'AWS',
+                'google': 'Google Cloud',
+                'microsoft': 'Azure',
+                'cloudflare': 'Cloudflare',
+                'digitalocean': 'DigitalOcean',
+                'ovh': 'OVH'
+            }
+            for key, val in providers.items():
+                if key in text:
+                    return val
+        except Exception:
+            return None
+        return None
+

--- a/libs/quickdetect/QuickDetect.py
+++ b/libs/quickdetect/QuickDetect.py
@@ -4,6 +4,7 @@ from libs.quickdetect.WordPressUtil import *
 from libs.quickdetect.DrupalUtil import *
 from libs.quickdetect.JQueryUtil import *
 from libs.quickdetect.AWSS3Util import *
+from libs.quickdetect.CloudIPUtil import CloudIPUtil
 
 class QuickDetect:
     def __init__(self, screen, webdriver, curses_util, logger):
@@ -39,6 +40,9 @@ class QuickDetect:
         jquery_version =0
         if isJQuery:
             jquery_version = jquery_util.getVersionString()
+
+        cloud_util = CloudIPUtil(self.current_url)
+        cloud_provider = cloud_util.get_provider()
             
         dojo_util = DojoUtil(self.driver)
         is_dojo = dojo_util.is_dojo()
@@ -51,6 +55,8 @@ class QuickDetect:
         S3 = ''
         if isS3:
             S3 = s3util.getUrlString()
+
+        has_cloud = cloud_provider is not None
             
             
         showscreen = True
@@ -95,6 +101,13 @@ class QuickDetect:
                 message = "Dojo Discovered"
                 if dojo_version is not None:
                     message += " ("+dojo_version+")"
+                self.screen.addstr(current_line, 4, message, curses.color_pair(2))
+                current_line += 1
+
+            if has_cloud:
+                message = "Cloud Provider Detected"
+                if cloud_provider:
+                    message += " (" + cloud_provider + ")"
                 self.screen.addstr(current_line, 4, message, curses.color_pair(2))
                 current_line += 1
             


### PR DESCRIPTION
## Summary
- detect cloud provider of current URL using IP whois lookup
- show provider in QuickDetect screen
- add CloudIPUtil helper class
- install `ipwhois` dependency

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68541c628590832ebb314f7aeeb2392e