### PR TITLE
Improve MX-based email provider detection

### DIFF
--- a/libs/quickdetect/MXEmailUtil.py
+++ b/libs/quickdetect/MXEmailUtil.py
@@ -1,0 +1,66 @@
+class MXEmailUtil:
+    def __init__(self, current_url, logger):
+        self.current_url = current_url
+        self.logger = logger
+
+    def _get_root_domain(self):
+        from urllib.parse import urlparse
+        parsed = urlparse(self.current_url)
+        domain = parsed.hostname
+        if not domain:
+            return None
+        parts = domain.split('.')
+        if len(parts) >= 2:
+            return '.'.join(parts[-2:])
+        return domain
+
+    def _query_mx_records(self, domain):
+        records = []
+        try:
+            import dns.resolver  # type: ignore
+            answers = dns.resolver.resolve(domain, 'MX')
+            for rdata in answers:
+                records.append(str(rdata.exchange).lower())
+        except Exception:
+            pass
+        if not records:
+            try:
+                import subprocess
+                output = subprocess.check_output(
+                    ['dig', '+short', domain, 'mx'],
+                    text=True,
+                    timeout=5
+                )
+                for line in output.splitlines():
+                    parts = line.strip().split()
+                    if parts:
+                        records.append(parts[-1].strip('.').lower())
+            except Exception:
+                pass
+        return records
+
+    def get_provider(self):
+        domain = self._get_root_domain()
+        if not domain:
+            return None
+        records = self._query_mx_records(domain)
+        providers = {
+            'outlook': 'Office 365',
+            'office365': 'Office 365',
+            'microsoft': 'Office 365',
+            'google': 'Google Workspace',
+            'googlemail': 'Google Workspace',
+            'aspmx': 'Google Workspace',
+            'zoho': 'Zoho Mail',
+            'yahoodns': 'Yahoo Mail',
+            'yahoo': 'Yahoo Mail',
+            'amazonaws': 'Amazon WorkMail',
+            'secureserver': 'GoDaddy Email',
+            'protonmail': 'ProtonMail',
+            'messagingengine.com': 'FastMail',
+        }
+        for rec in records:
+            for key, provider in providers.items():
+                if key in rec:
+                    return provider
+        return None

--- a/libs/quickdetect/O365Util.py
+++ b/libs/quickdetect/O365Util.py
@@ -1,0 +1,71 @@
+class O365Util:
+    def __init__(self, webdriver, current_url, logger):
+        self.webdriver = webdriver
+        self.current_url = current_url
+        self.logger = logger
+
+    def has_ms_bookings(self):
+        try:
+            from selenium.webdriver.common.by import By
+            frames = self.webdriver.find_elements(By.XPATH, "//iframe[contains(@src,'bookings')]")
+            for frame in frames:
+                src = frame.get_attribute('src')
+                if src and 'office' in src:
+                    return True
+        except Exception:
+            pass
+        return False
+
+    def is_office365(self):
+        try:
+            result = self.webdriver.execute_script("return typeof IsOwaPremiumBrowser !== 'undefined'")
+            if result:
+                return True
+        except Exception:
+            pass
+        # look for office urls
+        try:
+            from selenium.webdriver.common.by import By
+            tags = self.webdriver.find_elements(By.XPATH, "//script|//link|//iframe")
+            for tag in tags:
+                for attr in ['src', 'href']:
+                    url = tag.get_attribute(attr)
+                    if url and 'office' in url.lower():
+                        return True
+        except Exception:
+            pass
+        return False
+
+    def domain_uses_office365(self):
+        from urllib.parse import urlparse
+        import subprocess
+        parsed = urlparse(self.current_url)
+        domain = parsed.hostname
+        if not domain:
+            return False
+        parts = domain.split('.')
+        if len(parts) >= 2:
+            root_domain = '.'.join(parts[-2:])
+        else:
+            root_domain = domain
+        # try dnspython
+        try:
+            import dns.resolver  # type: ignore
+            answers = dns.resolver.resolve(root_domain, 'MX')
+            for rdata in answers:
+                exch = str(rdata.exchange).lower()
+                if 'outlook' in exch or 'office365' in exch or 'microsoft' in exch:
+                    return True
+        except Exception:
+            pass
+        # fallback to dig command
+        try:
+            output = subprocess.check_output(['dig', '+short', root_domain, 'mx'], text=True, timeout=5)
+            for line in output.splitlines():
+                line = line.lower()
+                if 'outlook' in line or 'office365' in line or 'microsoft' in line:
+                    return True
+        except Exception:
+            pass
+        return False
+

--- a/libs/quickdetect/QuickDetect.py
+++ b/libs/quickdetect/QuickDetect.py
@@ -5,6 +5,8 @@ from libs.quickdetect.DrupalUtil import *
 from libs.quickdetect.JQueryUtil import *
 from libs.quickdetect.AWSS3Util import *
 from libs.quickdetect.CloudIPUtil import CloudIPUtil
+from libs.quickdetect.O365Util import O365Util
+from libs.quickdetect.MXEmailUtil import MXEmailUtil
 
 class QuickDetect:
     def __init__(self, screen, webdriver, curses_util, logger):
@@ -55,6 +57,17 @@ class QuickDetect:
         S3 = ''
         if isS3:
             S3 = s3util.getUrlString()
+
+        email_util = MXEmailUtil(self.current_url, self.logger)
+        email_provider = email_util.get_provider()
+
+        o365_util = O365Util(self.driver, self.current_url, self.logger)
+        has_bookings = o365_util.has_ms_bookings()
+        is_o365 = (
+            o365_util.is_office365() or
+            o365_util.domain_uses_office365() or
+            (email_provider == 'Office 365')
+        )
 
         has_cloud = cloud_provider is not None
             
@@ -115,6 +128,22 @@ class QuickDetect:
                 message = "AWS S3 Bucket Detected"
                 if S3 is not None:
                     message += " ("+S3+")"
+                self.screen.addstr(current_line, 4, message, curses.color_pair(2))
+                current_line += 1
+
+            if email_provider:
+                message = "Email Provider Detected"
+                message += " (" + email_provider + ")"
+                self.screen.addstr(current_line, 4, message, curses.color_pair(2))
+                current_line += 1
+
+            if has_bookings:
+                message = "Microsoft Bookings Detected"
+                self.screen.addstr(current_line, 4, message, curses.color_pair(2))
+                current_line += 1
+
+            if is_o365:
+                message = "Office 365 Detected"
                 self.screen.addstr(current_line, 4, message, curses.color_pair(2))
                 current_line += 1
                 


### PR DESCRIPTION
## Summary
- add `MXEmailUtil` to detect popular email providers from MX records
- show detected email provider in QuickDetect output
- include provider result when determining if Office 365 is used

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68541fa58f40832e8356ab17a6bcda06