### PR TITLE
Reset terminal on exit

### DIFF
--- a/libs/mainmenu/mainframe.py
+++ b/libs/mainmenu/mainframe.py
@@ -1,5 +1,6 @@
 import curses
 import time
+import atexit
 from libs.utils.WebDriverUtil import *
 from libs.utils.cursesutil import *
 from libs.javascript.javascriptmenu import *
@@ -27,6 +28,7 @@ class mainframe:
         self.curses_util = CursesUtil()
         self.logger = logger
         self.jsinjector = JavascriptInjector()
+        atexit.register(self.curses_util.close_screen)
         # load plugin javascript
         self.plugins = [JSConsoleScript(self.jsinjector), JavascriptScript(self.jsinjector), HTMLToolsScript(self.jsinjector), AngularCustomJavascript(self.jsinjector)]
         

--- a/libs/utils/cursesutil.py
+++ b/libs/utils/cursesutil.py
@@ -37,6 +37,7 @@ class CursesUtil:
 
     def close_screen(self):
         curses.endwin()
+        system("reset")
         
     def show_header(self):
         self.screen.clear()


### PR DESCRIPTION
## Summary
- ensure curses cleans up the terminal
- register cleanup handler to always run on exit

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854245cca08832e8d456e4953feda6d