### PR TITLE
Enhance XSS URL payload generation

### DIFF
--- a/tests/test_xss.py
+++ b/tests/test_xss.py
@@ -7,7 +7,16 @@ class XSSUrlSuggestorTests(unittest.TestCase):
         url = 'http://example.com/page?param=1&test=2'
         suggestor = XSS_Url_Suggestor(url)
         urls = suggestor.get_xss_urls()
-        self.assertEqual(len(urls), 28)
+        expected_params = set(['param', 'test'] + suggestor.common_param_names)
+        self.assertEqual(len(urls), len(expected_params) * len(suggestor.xss_attacks))
+        self.assertTrue(all(u.startswith('http://example.com/page?') for u in urls))
+
+    def test_xss_url_suggestor_no_params(self):
+        url = 'http://example.com/page'
+        suggestor = XSS_Url_Suggestor(url)
+        urls = suggestor.get_xss_urls()
+        expected_params = set(suggestor.common_param_names)
+        self.assertEqual(len(urls), len(expected_params) * len(suggestor.xss_attacks))
         self.assertTrue(all(u.startswith('http://example.com/page?') for u in urls))
 
 


### PR DESCRIPTION
## Summary
- generate XSS payloads for URL parameters, form fields and common parameter names
- expose lists of XSS payloads and common parameters on `XSS_Url_Suggestor`
- add tests for pages with and without URL parameters

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685429a144d8832eb0d73e26e18d2c30