### PR TITLE
Fix goto URL handling

### DIFF
--- a/libs/mainmenu/mainframe.py
+++ b/libs/mainmenu/mainframe.py
@@ -145,11 +145,15 @@ class mainframe:
             return self.webdriver_util.getDriver(self.logger)
          
     def open_url(self, url):
+        if not url.startswith(('http://', 'https://')):
+            url = f'http://{url}'
+
         if self.driver == 'notset':
             self.driver = self.create_browser_instance()
+
         self.current_url = url
         try:
             self.driver.get(url)
             self.current_url = self.driver.current_url
-        except:
+        except Exception:
             pass


### PR DESCRIPTION
## Summary
- open_url now ensures the URL has a scheme

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685435651fa0832eb4f576c343682a64