### PR TITLE
Add URL history feature and startup parameter

### DIFF
--- a/console.py
+++ b/console.py
@@ -2,19 +2,23 @@
 # add owa to quickdetect - look for function IsOwaPremiumBrowser
 
 from libs.utils.logger import *
-from libs.mainmenu.mainframe import *		
+from libs.mainmenu.mainframe import *
+import sys
 
 if __name__ == '__main__':
-	log_file = FileLogger()
-	log_file.log('Webnuke started.')
-	
-	try:		
-		mainframe(log_file).show_main_screen()
-	except:
-		log_file.log('ERROR RUNNING WEBNUKE.')
-		raise
-		
-	log_file.log('Webnuke finished.')
+        log_file = FileLogger()
+        log_file.log('Webnuke started.')
+
+        try:
+                mf = mainframe(log_file)
+                if len(sys.argv) > 1:
+                        mf.open_url(sys.argv[1])
+                mf.show_main_screen()
+        except:
+                log_file.log('ERROR RUNNING WEBNUKE.')
+                raise
+
+        log_file.log('Webnuke finished.')
 
 
 		

--- a/libs/mainmenu/mainframe.py
+++ b/libs/mainmenu/mainframe.py
@@ -32,6 +32,27 @@ class mainframe:
         atexit.register(self.curses_util.close_screen)
         # load plugin javascript
         self.plugins = [JSConsoleScript(self.jsinjector), JavascriptScript(self.jsinjector), HTMLToolsScript(self.jsinjector), AngularCustomJavascript(self.jsinjector)]
+        self.url_history = []
+
+    def prompt_for_url(self):
+        if not self.url_history:
+            return self.curses_util.get_param("Enter the url").decode("utf-8")
+
+        self.screen.clear()
+        self.screen.border(0)
+        self.screen.addstr(2, 2, "Goto URL - select history or enter new")
+        y = 4
+        for i, url in enumerate(self.url_history, start=1):
+            self.screen.addstr(y, 4, f"{i}) {url}")
+            y += 1
+        self.screen.addstr(y, 4, "Enter number or URL:")
+        self.screen.refresh()
+        choice = self.screen.getstr(y, 23, 60).decode("utf-8")
+        if choice.isdigit():
+            idx = int(choice) - 1
+            if 0 <= idx < len(self.url_history):
+                return self.url_history[idx]
+        return choice
         
     def show_main_screen(self):
         self.logger.log("run_main")
@@ -72,7 +93,7 @@ class mainframe:
                     if len(mystr_elements) >= 2:
                         url = mystr_elements[1]
                     else:
-                        url = self.curses_util.get_param("Enter the url")
+                        url = self.prompt_for_url()
                     self.open_url(url)
 
                 if firstelement in ('13', 'debug'):
@@ -157,3 +178,5 @@ class mainframe:
             self.current_url = self.driver.current_url
         except Exception:
             pass
+        self.url_history.insert(0, self.current_url)
+        self.url_history = self.url_history[:5]

--- a/tests/test_mainframe.py
+++ b/tests/test_mainframe.py
@@ -1,0 +1,35 @@
+import unittest
+import atexit
+from libs.mainmenu.mainframe import mainframe
+
+class DummyLogger:
+    def log(self, text):
+        pass
+
+class DummyDriver:
+    def __init__(self):
+        self.current_url = ''
+    def get(self, url):
+        self.current_url = url
+
+class MainframeHistoryTests(unittest.TestCase):
+    def setUp(self):
+        class TestMainframe(mainframe):
+            def __init__(self_inner, logger):
+                super().__init__(logger)
+                atexit.unregister(self_inner.curses_util.close_screen)
+
+            def create_browser_instance(self_inner):
+                return DummyDriver()
+
+        self.mf = TestMainframe(DummyLogger())
+
+    def test_open_url_tracks_last_five(self):
+        urls = [f'http://example{i}.com' for i in range(6)]
+        for url in urls:
+            self.mf.open_url(url)
+        expected = list(reversed(urls[1:]))[:5]
+        self.assertEqual(self.mf.url_history, expected)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- remember last five visited URLs and prompt to choose them
- allow opening URL via command-line argument at startup
- test new `mainframe` history behavior

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68543686acf0832e9ac4b6894a24f19b