### PR TITLE
Fix crash when selecting WordPress CMS

### DIFF
--- a/libs/mainmenu/mainframe.py
+++ b/libs/mainmenu/mainframe.py
@@ -139,7 +139,10 @@ class mainframe:
                     AWSScreen(self.screen, self.driver, self.curses_util, self.logger).show()
 
                 if firstelement in ('11', 'cms'):
-                    CMSScreen(self.screen, self.driver, self.curses_util).show()
+                    if self.driver == 'notset':
+                        self.warning = "CMS requires a url is loaded, please set a url using GOTO"
+                    else:
+                        CMSScreen(self.screen, self.driver, self.curses_util).show()
 
                 if firstelement in ('4', 'html'):
                     HTMLScreen(self.screen, self.driver, self.curses_util, self.jsinjector).show()


### PR DESCRIPTION
## Summary
- prevent CMS menu from launching without an active browser

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685438838f88832eab794d25d20ac436