### PR TITLE
Fix CMS menu crash and add logging

### DIFF
--- a/libs/cms/cmsmenu.py
+++ b/libs/cms/cmsmenu.py
@@ -3,11 +3,12 @@ from libs.cms.cmscommands import CMSCommands
 
 
 class CMSScreen:
-    def __init__(self, screen, webdriver, curses_util):
+    def __init__(self, screen, webdriver, curses_util, logger):
         self.version = 2.0
         self.screen = screen
         self.driver = webdriver
         self.curses_util = curses_util
+        self.logger = logger
 
     def show(self):
         showscreen = True
@@ -24,11 +25,14 @@ class CMSScreen:
                 showscreen = False
             elif c == ord('1'):
                 self.curses_util.close_screen()
-                CMSCommands(self.driver, 'wordpress', self.curses_util).show()
+                self.logger.log('CMS menu: selected WordPress')
+                CMSCommands(self.driver, 'wordpress', self.curses_util, self.logger).show()
             elif c == ord('2'):
                 self.curses_util.close_screen()
-                CMSCommands(self.driver, 'drupal', self.curses_util).show()
+                self.logger.log('CMS menu: selected Drupal')
+                CMSCommands(self.driver, 'drupal', self.curses_util, self.logger).show()
             elif c == ord('3'):
                 self.curses_util.close_screen()
-                CMSCommands(self.driver, 'sitecore', self.curses_util).show()
+                self.logger.log('CMS menu: selected Sitecore')
+                CMSCommands(self.driver, 'sitecore', self.curses_util, self.logger).show()
         return

--- a/libs/mainmenu/mainframe.py
+++ b/libs/mainmenu/mainframe.py
@@ -142,7 +142,7 @@ class mainframe:
                     if self.driver == 'notset':
                         self.warning = "CMS requires a url is loaded, please set a url using GOTO"
                     else:
-                        CMSScreen(self.screen, self.driver, self.curses_util).show()
+                        CMSScreen(self.screen, self.driver, self.curses_util, self.logger).show()
 
                 if firstelement in ('4', 'html'):
                     HTMLScreen(self.screen, self.driver, self.curses_util, self.jsinjector).show()


### PR DESCRIPTION
## Summary
- add logger parameter to `CMSScreen`
- update `CMSCommands` to log debugging info and handle errors
- pass logger through main menu when opening CMS

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685439b6e31c832e96861ac12da0e38d