### PR TITLE
Improve CMS stability and logging

### DIFF
--- a/console.py
+++ b/console.py
@@ -4,6 +4,7 @@
 from libs.utils.logger import *
 from libs.mainmenu.mainframe import *
 import sys
+import traceback
 
 if __name__ == '__main__':
         log_file = FileLogger()
@@ -14,8 +15,9 @@ if __name__ == '__main__':
                 if len(sys.argv) > 1:
                         mf.open_url(sys.argv[1])
                 mf.show_main_screen()
-        except:
+        except Exception as e:
                 log_file.log('ERROR RUNNING WEBNUKE.')
+                log_file.log(traceback.format_exc())
                 raise
 
         log_file.log('Webnuke finished.')

--- a/libs/cms/cmscommands.py
+++ b/libs/cms/cmscommands.py
@@ -101,27 +101,41 @@ class CMSCommands:
     def show(self):
         showscreen = True
         self.logger.log(f'Starting CMSCommands.show for {self.cms_type}')
-        version, plugins = self.gather_info()
-        self.logger.log(f'Version: {version} | Plugins: {plugins}')
-        while showscreen:
-            screen = self.curses_util.get_screen()
-            screen.addstr(2, 2, f"{self.cms_type.capitalize()} Information")
-            line = 4
-            if version:
-                screen.addstr(line, 4, f"Version: {version}", curses.color_pair(2))
-                line += 1
-            if plugins:
-                screen.addstr(line, 4, "Plugins:", curses.color_pair(2))
-                line += 1
-                for p in plugins:
-                    screen.addstr(line, 6, p)
+        try:
+            version, plugins = self.gather_info()
+            self.logger.log(f'Version: {version} | Plugins: {plugins}')
+            while showscreen:
+                screen = self.curses_util.get_screen()
+                height, _ = screen.getmaxyx()
+                screen.addstr(2, 2, f"{self.cms_type.capitalize()} Information")
+                line = 4
+                if version:
+                    screen.addstr(line, 4, f"Version: {version}", curses.color_pair(2))
                     line += 1
-            else:
-                screen.addstr(line, 4, "No plugins detected")
-                line += 1
-            screen.addstr(22, 28, "PRESS M FOR MAIN MENU")
-            screen.refresh()
-            c = screen.getch()
-            if c in (ord('M'), ord('m')):
-                showscreen = False
+                if plugins:
+                    screen.addstr(line, 4, "Plugins:", curses.color_pair(2))
+                    line += 1
+                    max_lines = height - 3
+                    for p in plugins:
+                        if line >= max_lines:
+                            remaining = len(plugins) - (line - 5)
+                            screen.addstr(line, 6, f"...and {remaining} more")
+                            line += 1
+                            break
+                        screen.addstr(line, 6, p)
+                        line += 1
+                else:
+                    screen.addstr(line, 4, "No plugins detected")
+                    line += 1
+                screen.addstr(22, 28, "PRESS M FOR MAIN MENU")
+                screen.refresh()
+                c = screen.getch()
+                if c in (ord('M'), ord('m')):
+                    showscreen = False
+        except Exception as e:
+            import traceback
+            self.logger.log(f'Error displaying CMS info: {e}')
+            self.logger.log(traceback.format_exc())
+            self.curses_util.close_screen()
+            raise
         self.logger.log(f'Leaving CMSCommands.show for {self.cms_type}')


### PR DESCRIPTION
## Summary
- handle display errors in CMS command menu
- capture full traceback when Webnuke crashes
- ensure log persistence when resetting terminal

## Testing
- `pip install selenium pyvirtualdisplay ipwhois requests -q`
- `PYTHONPATH=. pytest -q`
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68543bab56cc832e86a641db4c5ed7a4