### PR TITLE
Add debug/error logging

### DIFF
--- a/console.py
+++ b/console.py
@@ -8,7 +8,7 @@ import traceback
 
 if __name__ == '__main__':
         log_file = FileLogger()
-        log_file.log('Webnuke started.')
+        log_file.debug('Webnuke started.')
 
         try:
                 mf = mainframe(log_file)
@@ -16,11 +16,11 @@ if __name__ == '__main__':
                         mf.open_url(sys.argv[1])
                 mf.show_main_screen()
         except Exception as e:
-                log_file.log('ERROR RUNNING WEBNUKE.')
-                log_file.log(traceback.format_exc())
+                log_file.error('ERROR RUNNING WEBNUKE.')
+                log_file.error(traceback.format_exc())
                 raise
 
-        log_file.log('Webnuke finished.')
+        log_file.debug('Webnuke finished.')
 
 
 		

--- a/libs/cms/cmscommands.py
+++ b/libs/cms/cmscommands.py
@@ -29,8 +29,8 @@ class CMSCommands:
                     if plugin:
                         plugins.add(plugin)
         except Exception as e:
-            self.logger.log(f'Error finding WordPress plugins: {e}')
-        self.logger.log(f'Found WordPress plugins: {plugins}')
+            self.logger.error(f'Error finding WordPress plugins: {e}')
+        self.logger.debug(f'Found WordPress plugins: {plugins}')
         return sorted(plugins)
 
     def _find_drupal_modules(self):
@@ -49,8 +49,8 @@ class CMSCommands:
                     if module:
                         modules.add(module)
         except Exception as e:
-            self.logger.log(f'Error finding Drupal modules: {e}')
-        self.logger.log(f'Found Drupal modules: {modules}')
+            self.logger.error(f'Error finding Drupal modules: {e}')
+        self.logger.debug(f'Found Drupal modules: {modules}')
         return sorted(modules)
 
     def _find_sitecore_modules(self):
@@ -70,40 +70,40 @@ class CMSCommands:
                     if module:
                         modules.add(module)
         except Exception as e:
-            self.logger.log(f'Error finding Sitecore modules: {e}')
-        self.logger.log(f'Found Sitecore modules: {modules}')
+            self.logger.error(f'Error finding Sitecore modules: {e}')
+        self.logger.debug(f'Found Sitecore modules: {modules}')
         return sorted(modules)
 
     def gather_info(self):
-        self.logger.log(f'gather_info called for {self.cms_type}')
+        self.logger.debug(f'gather_info called for {self.cms_type}')
         version = None
         plugins = []
         try:
             if self.cms_type == 'wordpress':
                 util = WordPressUtil(self.driver)
                 version = util.getVersionString()
-                self.logger.log(f'WordPress version: {version}')
+                self.logger.debug(f'WordPress version: {version}')
                 plugins = self._find_wordpress_plugins()
             elif self.cms_type == 'drupal':
                 util = DrupalUtil(self.driver)
                 version = util.getVersionString()
-                self.logger.log(f'Drupal version: {version}')
+                self.logger.debug(f'Drupal version: {version}')
                 plugins = self._find_drupal_modules()
             elif self.cms_type == 'sitecore':
                 util = SitecoreUtil(self.driver)
                 version = util.get_version_string()
-                self.logger.log(f'Sitecore version: {version}')
+                self.logger.debug(f'Sitecore version: {version}')
                 plugins = self._find_sitecore_modules()
         except Exception as e:
-            self.logger.log(f'Error gathering CMS info: {e}')
+            self.logger.error(f'Error gathering CMS info: {e}')
         return version, plugins
 
     def show(self):
         showscreen = True
-        self.logger.log(f'Starting CMSCommands.show for {self.cms_type}')
+        self.logger.debug(f'Starting CMSCommands.show for {self.cms_type}')
         try:
             version, plugins = self.gather_info()
-            self.logger.log(f'Version: {version} | Plugins: {plugins}')
+            self.logger.debug(f'Version: {version} | Plugins: {plugins}')
             while showscreen:
                 screen = self.curses_util.get_screen()
                 height, _ = screen.getmaxyx()
@@ -134,8 +134,8 @@ class CMSCommands:
                     showscreen = False
         except Exception as e:
             import traceback
-            self.logger.log(f'Error displaying CMS info: {e}')
-            self.logger.log(traceback.format_exc())
+            self.logger.error(f'Error displaying CMS info: {e}')
+            self.logger.error(traceback.format_exc())
             self.curses_util.close_screen()
             raise
-        self.logger.log(f'Leaving CMSCommands.show for {self.cms_type}')
+        self.logger.debug(f'Leaving CMSCommands.show for {self.cms_type}')

--- a/libs/utils/logger.py
+++ b/libs/utils/logger.py
@@ -1,11 +1,26 @@
+import os
+
+
 class FileLogger:
+    """Simple logger that writes messages to a file and stdout."""
+
     def __init__(self):
-        self.log_path = '/tmp/webnuke.log'
-    
-    def log(self, text):
+        # Default to logging in the current working directory
+        self.log_path = os.path.join(os.getcwd(), 'webnuke.log')
+
+    def _write(self, text: str) -> None:
+        with open(self.log_path, 'a', encoding='utf-8') as logfile:
+            logfile.write(f'{text}\n')
+
+    def log(self, text: str) -> None:
         print(text)
-        with open(self.log_path, "a", encoding="utf-8") as logfile:
-            logfile.write(f"{text}\n")
+        self._write(text)
+
+    def debug(self, text: str) -> None:
+        self.log(f'DEBUG: {text}')
+
+    def error(self, text: str) -> None:
+        self.log(f'ERROR: {text}')
         
 
 


### PR DESCRIPTION
## Summary
- extend FileLogger with debug and error helpers
- log debug/error info in console entrypoint
- emit debug/error messages in CMSCommands
- default webnuke.log to current directory

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pip install pyvirtualdisplay selenium requests ipwhois`
- `python3 -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68543e04e124832eb9ad94312a1a9817