### PR TITLE
Fix CMS screen curses import

### DIFF
--- a/libs/cms/cmscommands.py
+++ b/libs/cms/cmscommands.py
@@ -1,4 +1,5 @@
 from selenium.webdriver.common.by import By
+import curses
 from libs.quickdetect.WordPressUtil import WordPressUtil
 from libs.quickdetect.DrupalUtil import DrupalUtil
 from libs.quickdetect.SitecoreUtil import SitecoreUtil


### PR DESCRIPTION
## Summary
- import curses in `CMSCommands` to use color pairs

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6854403195f4832eb80969ee2aea9a9d