### PR TITLE
Refactor AWS bucket URL extraction

### DIFF
--- a/libs/aws/awscommands.py
+++ b/libs/aws/awscommands.py
@@ -10,50 +10,38 @@ class AWSCommands:
         
     def show_bucket_report(self):
         print("finding buckets...")
-        self.extract_bucket_urls_from_meta_tags()
-        self.extract_bucket_urls_from_image_tags()
-        self.extract_bucket_urls_from_link_tags()
-        self.extract_bucket_urls_from_javascript_tags()
-        self.extract_bucket_urls_from_anchor_tags()
+        self.extract_bucket_urls("//meta", "content")
+        self.extract_bucket_urls("//img", "src")
+        self.extract_bucket_urls("//link", "href")
+        self.extract_bucket_urls("//script", "src")
+        self.extract_bucket_urls("//a", "href")
         print('')
         print('')
         input("Press ENTER to return to menu.")
+
+    def extract_bucket_urls(self, xpath: str, attribute: str) -> None:
+        """Generic helper to look for bucket URLs in matching elements."""
+        for tag in self.driver.find_elements(By.XPATH, xpath):
+            self.process_url(tag.get_attribute(attribute))
         
     def extract_bucket_urls_from_meta_tags(self):
-        metatags = self.driver.find_elements(By.XPATH, "//meta")
-        for tag in metatags:
-            contenturl = tag.get_attribute('content')
-            self.process_url(contenturl)
+        self.extract_bucket_urls("//meta", "content")
 
     def extract_bucket_urls_from_image_tags(self):
-        metatags = self.driver.find_elements(By.XPATH, "//img")
-        for tag in metatags:
-            contenturl = tag.get_attribute('src')
-            self.process_url(contenturl)
+        self.extract_bucket_urls("//img", "src")
 
     def extract_bucket_urls_from_link_tags(self):
-        metatags = self.driver.find_elements(By.XPATH, "//link")
-        for tag in metatags:
-            contenturl = tag.get_attribute('href')
-            self.process_url(contenturl)
+        self.extract_bucket_urls("//link", "href")
 
     def extract_bucket_urls_from_anchor_tags(self):
-        metatags = self.driver.find_elements(By.XPATH, "//a")
-        for tag in metatags:
-            contenturl = tag.get_attribute('href')
-            self.process_url(contenturl)
-
+        self.extract_bucket_urls("//a", "href")
 
     def extract_bucket_urls_from_javascript_tags(self):
-        metatags = self.driver.find_elements(By.XPATH, "//script")
-        for tag in metatags:
-            contenturl = tag.get_attribute('src')
-            self.process_url(contenturl)
+        self.extract_bucket_urls("//script", "src")
 
                         
-    def process_url(self, url):
-        if url:
-            for s3host in self.known_s3_hosts:
-                if s3host in url:
-                    self.logger.log(url)
+    def process_url(self, url: str) -> None:
+        """Log the URL if it belongs to a known S3 host."""
+        if url and any(s3host in url for s3host in self.known_s3_hosts):
+            self.logger.log(url)
     


### PR DESCRIPTION
## Summary
- consolidate repetitive bucket URL extraction code in `AWSCommands`
- tighten `process_url` and document helper

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854c7d6e288832e9cee4370577b81f4