### PR TITLE
Fix QuickDetect Angular utility bug

### DIFF
--- a/libs/quickdetect/AngularUtil.py
+++ b/libs/quickdetect/AngularUtil.py
@@ -88,7 +88,7 @@ class AngularUtilV2:
                             for (prop in res) {
                                 var mytype = typeof(res[prop]);
                                 if(mytype=="string" || mytype == "number" || mytype == "boolean"){
-                                    rtnData.push({'name': prop, 'value': controller[prop], 'type': mytype});
+                                    rtnData.push({'name': prop, 'value': res[prop], 'type': mytype});
                                 }
                                 if(mytype=="object"){
                                     rtnData.push({'name': prop, 'value': '', 'type': mytype});

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,2 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))


### PR DESCRIPTION
## Summary
- fix undefined variable in `AngularUtil.get_components_from_component_name`
- ensure tests can import package by adding `tests/conftest.py`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6854e07bffdc832ebbd9057797afe7a3