### PR TITLE
Fix url_history duplicate handling

### DIFF
--- a/libs/mainmenu/mainframe.py
+++ b/libs/mainmenu/mainframe.py
@@ -187,6 +187,8 @@ class mainframe:
             self.current_url = self.driver.current_url
         except Exception:
             pass
+        while self.current_url in self.url_history:
+            self.url_history.remove(self.current_url)
         self.url_history.insert(0, self.current_url)
         self.url_history = self.url_history[:5]
 

--- a/tests/test_mainframe.py
+++ b/tests/test_mainframe.py
@@ -31,5 +31,14 @@ class MainframeHistoryTests(unittest.TestCase):
         expected = list(reversed(urls[1:]))[:5]
         self.assertEqual(self.mf.url_history, expected)
 
+    def test_open_url_removes_duplicates(self):
+        first = 'http://example.com'
+        second = 'http://test.com'
+        self.mf.open_url(first)
+        self.mf.open_url(second)
+        self.mf.open_url(first)
+        self.assertEqual(self.mf.url_history[0], first)
+        self.assertEqual(self.mf.url_history.count(first), 1)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- prevent duplicates in `mainframe.open_url` history
- test history duplicate removal

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854f2100aa0832ea38dd50a630fbf6b