### PR TITLE
Add onmessage detection and postMessage test

### DIFF
--- a/libs/quickdetect/OnMessageUtil.py
+++ b/libs/quickdetect/OnMessageUtil.py
@@ -1,0 +1,19 @@
+class OnMessageUtil:
+    def __init__(self, webdriver):
+        self.webdriver = webdriver
+
+    def is_set(self):
+        try:
+            return bool(self.webdriver.execute_script("return !!window.onmessage"))
+        except Exception:
+            return False
+
+    def checks_origin(self):
+        try:
+            script = "return window.onmessage && window.onmessage.toString()"
+            handler = self.webdriver.execute_script(script)
+            if not handler:
+                return False
+            return 'origin' in handler
+        except Exception:
+            return False

--- a/libs/quickdetect/QuickDetect.py
+++ b/libs/quickdetect/QuickDetect.py
@@ -9,6 +9,7 @@ from libs.quickdetect.CloudIPUtil import CloudIPUtil
 from libs.quickdetect.O365Util import O365Util
 from libs.quickdetect.MXEmailUtil import MXEmailUtil
 from libs.quickdetect.WindowNameUtil import WindowNameUtil
+from libs.quickdetect.OnMessageUtil import OnMessageUtil
 
 class QuickDetect:
     def __init__(self, screen, webdriver, curses_util, logger):
@@ -82,6 +83,10 @@ class QuickDetect:
         window_name_util = WindowNameUtil(self.driver)
         window_name_set = window_name_util.is_set()
         window_name_value = window_name_util.get_value() if window_name_set else None
+
+        on_message_util = OnMessageUtil(self.driver)
+        on_message_set = on_message_util.is_set()
+        on_message_checks_origin = on_message_util.checks_origin() if on_message_set else False
             
             
         showscreen = True
@@ -171,6 +176,15 @@ class QuickDetect:
                 if window_name_value:
                     truncated = str(window_name_value)[:30]
                     message += f" (\"{truncated}\")"
+                self.screen.addstr(current_line, 4, message, curses.color_pair(2))
+                current_line += 1
+
+            if on_message_set:
+                message = "onmessage handler set"
+                if on_message_checks_origin:
+                    message += " (origin checked)"
+                else:
+                    message += " (origin not checked)"
                 self.screen.addstr(current_line, 4, message, curses.color_pair(2))
                 current_line += 1
                 

--- a/libs/xss/xsscommands.py
+++ b/libs/xss/xsscommands.py
@@ -43,6 +43,17 @@ class XSSCommands:
         except Exception as exc:
             print(f"Failed to write exploit file: {exc}")
         input("Press ENTER to return to menu.")
+
+    def test_post_message(self, message=None):
+        if message is None:
+            message = "test"
+        script = f"window.postMessage('{message}', '*');"
+        try:
+            self.driver.execute_script(script)
+            print("postMessage sent")
+        except Exception as exc:
+            print(f"Failed to send postMessage: {exc}")
+        input("Press ENTER to return to menu.")
         
 
 

--- a/libs/xss/xssmenu.py
+++ b/libs/xss/xssmenu.py
@@ -21,6 +21,7 @@ class XSSScreen:
             self.screen.addstr(2, 2, "XSS")
             self.screen.addstr(4, 5, "1) Find XSS")
             self.screen.addstr(5, 5, "2) Create window.name exploit")
+            self.screen.addstr(6, 5, "3) Test postMessage")
 
 
             
@@ -42,6 +43,14 @@ class XSSScreen:
                 except KeyboardInterrupt:
                     payload = None
                 self.commands.create_window_name_exploit(payload)
+
+            if c == ord('3'):
+                self.curses_util.close_screen()
+                try:
+                    message = input("Enter postMessage payload: ") or "test"
+                except KeyboardInterrupt:
+                    message = "test"
+                self.commands.test_post_message(message)
                                 
         return
         


### PR DESCRIPTION
## Summary
- detect use of `onmessage` with origin checks in QuickDetect
- add utility for `onmessage` inspection
- extend XSS screen with postMessage option and implement test

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854f7c009ec832e96150c6cf3002e67