### PR TITLE
Add javascript shell

### DIFF
--- a/libs/javascript/javascriptmenu.py
+++ b/libs/javascript/javascriptmenu.py
@@ -4,6 +4,7 @@ from selenium.common.exceptions import WebDriverException
 from libs.javascript.javascriptscript import *
 from libs.javascript.javascriptcommands import *
 from libs.javascript.jswalker import *
+from libs.javascript.jsshell import JSShell
 
 
 class JavascriptScreen:
@@ -28,6 +29,7 @@ class JavascriptScreen:
             self.screen.addstr(6, 5, "3) Run all js functions without args")
             self.screen.addstr(7, 5, "4) Show Cookies accessable by Javascript")
             self.screen.addstr(8, 5, "5) Walk Javascript Functions")
+            self.screen.addstr(9, 5, "6) Javascript Shell")
 
 
             
@@ -58,6 +60,10 @@ class JavascriptScreen:
                 self.curses_util.close_screen()
                 self.jswalker.start_walk_tree()
                 #self.commands.walk_functions()
+
+            if c == ord('6'):
+                self.curses_util.close_screen()
+                JSShell(self.driver).run()
                     
         return
         

--- a/libs/javascript/jsshell.py
+++ b/libs/javascript/jsshell.py
@@ -1,0 +1,73 @@
+class JSShell:
+    def __init__(self, webdriver):
+        self.driver = webdriver
+        self.cwd = 'window'
+
+    def run(self):
+        print('Webnuke Javascript Shell. Type "exit" to return.')
+        while True:
+            try:
+                cmd = input(f'{self.cwd}> ').strip()
+            except EOFError:
+                break
+            if cmd in ('exit', 'quit'):
+                break
+            if not cmd:
+                continue
+            try:
+                self.handle_command(cmd)
+            except Exception as e:
+                print(f'Error: {e}')
+
+    def handle_command(self, cmd):
+        if cmd.startswith('cd '):
+            self.change_dir(cmd[3:].strip())
+        elif cmd == 'pwd':
+            print(self.cwd)
+        elif cmd.startswith('cat '):
+            self.cat_property(cmd[4:].strip())
+        elif cmd.startswith('bash '):
+            self.run_js(cmd[5:].strip())
+        elif cmd.startswith('man '):
+            self.show_function_help(cmd[4:].strip())
+        else:
+            print('Unknown command')
+
+    def change_dir(self, path):
+        if path in ('/', 'window'):
+            self.cwd = 'window'
+            return
+        if path == '..':
+            parts = self.cwd.split('.')
+            if len(parts) > 1:
+                self.cwd = '.'.join(parts[:-1])
+            else:
+                self.cwd = 'window'
+            return
+        new_path = path if path.startswith('window') else f'{self.cwd}.{path}'
+        exists = self.driver.execute_script(f'return typeof {new_path} !== "undefined";')
+        if exists:
+            self.cwd = new_path
+        else:
+            print('Path does not exist')
+
+    def cat_property(self, prop):
+        script = f'return {self.cwd}.{prop};'
+        result = self.driver.execute_script(script)
+        print(result)
+
+    def run_js(self, js):
+        script = f'with({self.cwd}){{ {js}; }}'
+        self.driver.execute_script(script)
+
+    def show_function_help(self, fn):
+        script = f'try{{return {self.cwd}.{fn}.toString();}}catch(e){{return null;}}'
+        result = self.driver.execute_script(script)
+        if result:
+            first_line = result.split('\n', 1)[0]
+            if '(' in first_line and ')' in first_line:
+                args = first_line[first_line.find('(')+1:first_line.find(')')]
+                print(f'Arguments: {args}')
+            print(result)
+        else:
+            print('Function not found')


### PR DESCRIPTION
## Summary
- add JSShell class for basic javascript terminal functionality
- extend javascript menu with option to launch shell

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'selenium')*

------
https://chatgpt.com/codex/tasks/task_e_6855a4fa4e04832e94d80d6e886d1163