### PR TITLE
Add ls command to javascript shell

### DIFF
--- a/tests/test_jsshell.py
+++ b/tests/test_jsshell.py
@@ -1,0 +1,38 @@
+import unittest
+import io
+from contextlib import redirect_stdout
+from libs.javascript.jsshell import JSShell
+
+class DummyDriver:
+    def __init__(self, entries=None):
+        self.entries = entries or []
+    def execute_script(self, script):
+        return self.entries
+
+class JSShellTests(unittest.TestCase):
+    def setUp(self):
+        self.entries = [
+            {'name': 'foo', 'type': 'string', 'size': 3},
+            {'name': 'bar', 'type': 'function', 'size': 10}
+        ]
+        self.driver = DummyDriver(self.entries)
+        self.shell = JSShell(self.driver)
+
+    def test_ls_lists_names(self):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            self.shell.handle_command('ls')
+        output = buf.getvalue().splitlines()
+        self.assertIn('foo', output)
+        self.assertIn('bar()', output)
+
+    def test_ls_la_shows_sizes(self):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            self.shell.handle_command('ls -la')
+        output = buf.getvalue().splitlines()
+        self.assertIn('foo\t3', output)
+        self.assertIn('bar()\t10', output)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `ls` and `ls -la` commands to the JS shell
- implement directory listing logic
- test js shell ls commands

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855a85551a8832e8cd0095ecd437b86