### PR TITLE
Fix JS shell crash with uninitialized driver

### DIFF
--- a/libs/javascript/javascriptmenu.py
+++ b/libs/javascript/javascriptmenu.py
@@ -63,7 +63,11 @@ class JavascriptScreen:
 
             if c == ord('6'):
                 self.curses_util.close_screen()
-                JSShell(self.driver).run()
+                if self.driver == 'notset':
+                    print("Javascript Shell requires a loaded page. Use GOTO to open a URL first.")
+                    input("Press ENTER to continue...")
+                else:
+                    JSShell(self.driver).run()
                     
         return
         


### PR DESCRIPTION
## Summary
- prevent JS shell from running when no driver is loaded

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'selenium')*

------
https://chatgpt.com/codex/tasks/task_e_6855ab77c67c832e83c93c3612ccba16