### PR TITLE
Add goto command to JSShell

### DIFF
--- a/libs/javascript/jsshell.py
+++ b/libs/javascript/jsshell.py
@@ -34,6 +34,8 @@ class JSShell:
             self.cat_property(cmd[4:].strip())
         elif cmd.startswith('bash '):
             self.run_js(cmd[5:].strip())
+        elif cmd.startswith('goto '):
+            self.goto_url(cmd[5:].strip())
         elif cmd.startswith('man '):
             self.show_function_help(cmd[4:].strip())
         elif cmd == 'ls':
@@ -71,6 +73,18 @@ class JSShell:
     def run_js(self, js):
         script = f'with({self.cwd}){{ {js}; }}'
         self.driver.execute_script(script)
+
+    def goto_url(self, url: str) -> None:
+        if not url:
+            print('Usage: goto <url>')
+            return
+        if not url.startswith(('http://', 'https://')):
+            url = f'http://{url}'
+        try:
+            self.driver.get(url)
+            self.cwd = 'this'
+        except Exception as e:
+            print(f'Error loading URL: {e}')
 
     def show_function_help(self, fn):
         script = f'try{{return {self.cwd}.{fn}.toString();}}catch(e){{return null;}}'

--- a/tests/test_jsshell.py
+++ b/tests/test_jsshell.py
@@ -6,8 +6,11 @@ from libs.javascript.jsshell import JSShell
 class DummyDriver:
     def __init__(self, entries=None):
         self.entries = entries or []
+        self.current_url = ''
     def execute_script(self, script):
         return self.entries
+    def get(self, url):
+        self.current_url = url
 
 class JSShellTests(unittest.TestCase):
     def setUp(self):
@@ -37,6 +40,12 @@ class JSShellTests(unittest.TestCase):
         expected_bar = f"{JSShell.COLOR_EXECUTABLE}bar(){JSShell.COLOR_RESET}\t10"
         self.assertIn(expected_foo, output)
         self.assertIn(expected_bar, output)
+
+    def test_goto_navigates(self):
+        url = 'https://example.com'
+        self.shell.handle_command(f'goto {url}')
+        self.assertEqual(self.driver.current_url, url)
+        self.assertEqual(self.shell.cwd, 'this')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- allow `goto <url>` in `JSShell`
- test that goto navigates the browser

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `bash install-requirements.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855ac8f97b4832ea4e14d673f01fb55