### PR TITLE
Implement persistent URL history

### DIFF
--- a/libs/javascript/javascriptmenu.py
+++ b/libs/javascript/javascriptmenu.py
@@ -8,12 +8,13 @@ from libs.javascript.jsshell import JSShell
 
 
 class JavascriptScreen:
-    def __init__(self, screen, webdriver, curses_util, jsinjector):
+    def __init__(self, screen, webdriver, curses_util, jsinjector, url_callback=None):
         self.version = 2.0
         self.screen = screen
         self.driver = webdriver
         self.curses_util = curses_util
         self.jsinjector = jsinjector
+        self.url_callback = url_callback
         self.commands = JavascriptCommands(self.driver, self.jsinjector)
         self.jswalker = JSWalker(self.driver, self.jsinjector)
         
@@ -67,7 +68,7 @@ class JavascriptScreen:
                     print("Javascript Shell requires a loaded page. Use GOTO to open a URL first.")
                     input("Press ENTER to continue...")
                 else:
-                    JSShell(self.driver).run()
+                    JSShell(self.driver, self.url_callback).run()
                     
         return
         

--- a/libs/javascript/jsshell.py
+++ b/libs/javascript/jsshell.py
@@ -9,8 +9,9 @@ class JSShell:
 
     COMMANDS = ['cd', 'pwd', 'cat', 'bash', 'goto', 'man', 'ls', 'ls -la', 'exit', 'quit']
 
-    def __init__(self, webdriver):
+    def __init__(self, webdriver, url_callback=None):
         self.driver = webdriver
+        self.url_callback = url_callback
         # start at the root of the javascript context
         self.cwd = 'this'
 
@@ -89,7 +90,10 @@ class JSShell:
         if not url.startswith(('http://', 'https://')):
             url = f'http://{url}'
         try:
-            self.driver.get(url)
+            if self.url_callback:
+                self.url_callback(url)
+            else:
+                self.driver.get(url)
             self.cwd = 'this'
         except Exception as e:
             print(f'Error loading URL: {e}')

--- a/tests/test_jsshell.py
+++ b/tests/test_jsshell.py
@@ -20,7 +20,11 @@ class JSShellTests(unittest.TestCase):
             {'name': 'bar', 'type': 'function', 'size': 10}
         ]
         self.driver = DummyDriver(self.entries)
-        self.shell = JSShell(self.driver)
+        self.history = []
+        def cb(url):
+            self.history.append(url)
+            self.driver.get(url)
+        self.shell = JSShell(self.driver, cb)
 
     def test_ls_lists_names(self):
         buf = io.StringIO()
@@ -47,6 +51,11 @@ class JSShellTests(unittest.TestCase):
         self.shell.handle_command(f'goto {url}')
         self.assertEqual(self.driver.current_url, url)
         self.assertEqual(self.shell.cwd, 'this')
+
+    def test_goto_updates_history(self):
+        url = 'https://example.org'
+        self.shell.handle_command(f'goto {url}')
+        self.assertIn(url, self.history)
 
     def test_command_autocomplete(self):
         with patch('readline.get_line_buffer', return_value='l'):

--- a/tests/test_mainframe.py
+++ b/tests/test_mainframe.py
@@ -1,5 +1,6 @@
 import unittest
 import atexit
+import os
 from libs.mainmenu.mainframe import mainframe
 
 class DummyLogger:
@@ -22,6 +23,11 @@ class MainframeHistoryTests(unittest.TestCase):
             def create_browser_instance(self_inner):
                 return DummyDriver()
 
+        # ensure history file is removed
+        try:
+            os.remove(os.path.join(os.getcwd(), 'history.txt'))
+        except FileNotFoundError:
+            pass
         self.mf = TestMainframe(DummyLogger())
 
     def test_open_url_tracks_last_five(self):
@@ -39,6 +45,14 @@ class MainframeHistoryTests(unittest.TestCase):
         self.mf.open_url(first)
         self.assertEqual(self.mf.url_history[0], first)
         self.assertEqual(self.mf.url_history.count(first), 1)
+
+    def test_history_persisted(self):
+        url = 'http://persist.com'
+        self.mf.open_url(url)
+        # reload mainframe to load history from file
+        new_mf = self.mf.__class__(DummyLogger())
+        atexit.unregister(new_mf.curses_util.close_screen)
+        self.assertIn(url, new_mf.url_history)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- load and save URL history in `history.txt`
- allow Javascript shell to update history via callback
- wire history-saving into mainframe
- tests for persistence and shell updates

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855aea00528832e9b175ff7984ada59