### PR TITLE
Improve JSShell nested completion

### DIFF
--- a/tests/test_jsshell.py
+++ b/tests/test_jsshell.py
@@ -83,5 +83,18 @@ class JSShellTests(unittest.TestCase):
                 i += 1
         self.assertEqual(completions, ['foo'])
 
+    def test_nested_property_autocomplete(self):
+        with patch('readline.get_line_buffer', return_value='cat obj/'), \
+             patch.object(self.shell, 'get_property_names', return_value=['inner', 'leaf']):
+            completions = []
+            i = 0
+            while True:
+                res = self.shell.complete('', i)
+                if res is None:
+                    break
+                completions.append(res)
+                i += 1
+        self.assertEqual(completions, ['obj/inner', 'obj/leaf'])
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- enhance JSShell to resolve javascript paths and handle nested paths
- extend completion logic so Tab works within subdirectories
- update tests for new nested completion behaviour

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855b272954c832ebf542e1f863bee9d