### PR TITLE
Add builtin browser object highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Detect technologies in use not by parsing files or applying regex to file names 
 - Basic unit tests to help ensure reliability
 - Main menu items can also be selected by entering their number
 - Detect window.name usage and generate exploit file
+- Builtin browser functions are highlighted in the Javascript shell
 
 
 ## JSCONSOLE
@@ -94,9 +95,13 @@ The type 'test' option is useful when dealing with Ajax calls.
 
 ### Javascript Options
                                                                               
-1. Find URLS within Javascript Global Properties                          
-2. Show Javascript functions of Document                                  
-3. Run all js functions without args  
+1. Find URLS within Javascript Global Properties
+2. Show Javascript functions of Document
+3. Run all js functions without args
+4. Show Cookies accessable by Javascript
+5. Walk Javascript Functions
+6. Javascript Shell
+7. Update builtin object list
 
 
 ## AngularJS

--- a/libs/javascript/browser_builtins.txt
+++ b/libs/javascript/browser_builtins.txt
@@ -1,0 +1,3 @@
+alert
+prompt
+confirm

--- a/libs/javascript/javascriptcommands.py
+++ b/libs/javascript/javascriptcommands.py
@@ -140,6 +140,18 @@ var full = jsproberesults.join(','); console.log(full);
         print('')
         input("Press ENTER to return to menu.")
 
+    def dump_browser_objects(self, filepath='libs/javascript/browser_builtins.txt'):
+        try:
+            self.driver.get('about:blank')
+            objects = self.driver.execute_script('return Object.getOwnPropertyNames(this);')
+            with open(filepath, 'w') as fh:
+                for name in sorted(objects):
+                    fh.write(name + '\n')
+            print(f'Saved {len(objects)} objects to {filepath}')
+        except WebDriverException as e:
+            print(f'Selenium Exception: Message: {str(e)}')
+        input("Press ENTER to return to menu.")
+
 
 
             

--- a/libs/javascript/javascriptmenu.py
+++ b/libs/javascript/javascriptmenu.py
@@ -31,6 +31,7 @@ class JavascriptScreen:
             self.screen.addstr(7, 5, "4) Show Cookies accessable by Javascript")
             self.screen.addstr(8, 5, "5) Walk Javascript Functions")
             self.screen.addstr(9, 5, "6) Javascript Shell")
+            self.screen.addstr(10, 5, "7) Update builtin object list")
 
 
             
@@ -69,6 +70,10 @@ class JavascriptScreen:
                     input("Press ENTER to continue...")
                 else:
                     JSShell(self.driver, self.url_callback).run()
-                    
+
+            if c == ord('7'):
+                self.curses_util.close_screen()
+                self.commands.dump_browser_objects()
+
         return
         

--- a/libs/javascript/jsshell.py
+++ b/libs/javascript/jsshell.py
@@ -1,4 +1,5 @@
 import readline
+import os
 
 
 class JSShell:
@@ -6,6 +7,7 @@ class JSShell:
     COLOR_FOLDER = '\033[94m'
     COLOR_EXECUTABLE = '\033[92m'
     COLOR_FILE = '\033[0m'
+    COLOR_BUILTIN = '\033[95m'
 
     COMMANDS = ['cd', 'pwd', 'cat', 'bash', 'goto', 'man', 'ls', 'ls -la', 'exit', 'quit']
 
@@ -14,6 +16,12 @@ class JSShell:
         self.url_callback = url_callback
         # start at the root of the javascript context
         self.cwd = 'this'
+        self.builtins = set()
+
+        builtin_path = os.path.join(os.path.dirname(__file__), 'browser_builtins.txt')
+        if os.path.exists(builtin_path):
+            with open(builtin_path, 'r') as fh:
+                self.builtins = {line.strip() for line in fh if line.strip()}
 
         readline.set_completer(self.complete)
         readline.parse_and_bind('tab: complete')
@@ -134,7 +142,10 @@ class JSShell:
             print('Function not found')
 
     def _colorize_name(self, name: str, type_: str) -> str:
-        if type_ == 'object':
+        base_name = name.split('(')[0].rstrip('/')
+        if base_name in self.builtins:
+            color = self.COLOR_BUILTIN
+        elif type_ == 'object':
             color = self.COLOR_FOLDER
         elif type_ == 'function':
             color = self.COLOR_EXECUTABLE

--- a/tests/test_jsshell.py
+++ b/tests/test_jsshell.py
@@ -26,6 +26,15 @@ class JSShellTests(unittest.TestCase):
             self.driver.get(url)
         self.shell = JSShell(self.driver, cb)
 
+    def test_builtin_color(self):
+        self.shell.builtins = {'foo'}
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            self.shell.handle_command('ls')
+        output = buf.getvalue().splitlines()
+        expected_foo = f"{JSShell.COLOR_BUILTIN}foo{JSShell.COLOR_RESET}"
+        self.assertIn(expected_foo, output)
+
     def test_ls_lists_names(self):
         buf = io.StringIO()
         with redirect_stdout(buf):


### PR DESCRIPTION
## Summary
- highlight builtin browser objects in JSShell
- allow updating builtin list from Javascript menu
- document new features in README
- test builtin highlighting behaviour

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6855b38e71c0832ea22d5f2a1391d7cb