### PR TITLE
Add script command to JSShell

### DIFF
--- a/tests/test_jsshell.py
+++ b/tests/test_jsshell.py
@@ -125,5 +125,17 @@ class JSShellTests(unittest.TestCase):
             shell.inject_custom_scripts()
             self.assertTrue(driver.scripts)
 
+    def test_script_logs_session(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, 'log.txt')
+            with patch('builtins.input', side_effect=['ls', 'exit']):
+                buf = io.StringIO()
+                with redirect_stdout(buf):
+                    self.shell.handle_command(f'script {path}')
+            with open(path, 'r', encoding='utf-8') as fh:
+                content = fh.read()
+            self.assertIn('ls', content)
+            self.assertIn('foo', content)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- extend `JSShell` with a `script` command
- implement `script_session` helper that logs inputs/outputs to file
- test that script logging works

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855b94d77e8832e8b34a752570c330d