### PR TITLE
Add /proc subsystem to JSShell

### DIFF
--- a/tests/test_jsshell.py
+++ b/tests/test_jsshell.py
@@ -137,5 +137,25 @@ class JSShellTests(unittest.TestCase):
             self.assertIn('ls', content)
             self.assertIn('foo', content)
 
+    def test_cd_proc(self):
+        self.shell.change_dir('/proc')
+        self.assertEqual(self.shell.proc_path, '')
+        self.assertEqual(self.shell._display_path(), '/proc')
+
+    def test_cat_proc_event(self):
+        self.shell.proc_path = 'form_0/txt'
+        with patch.object(self.shell, '_proc_cat', return_value='fn') as mock:
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                self.shell.cat_property('onfocus')
+            self.assertIn('fn', buf.getvalue())
+            mock.assert_called_with('form_0/txt/onfocus')
+
+    def test_run_proc_event(self):
+        self.shell.proc_path = 'window'
+        with patch.object(self.shell, '_proc_run', return_value=None) as mock:
+            self.shell.run_js('onload')
+            mock.assert_called_with('window/onload')
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- enhance `JSShell` with `/proc` subsystem for inspecting bound events and service workers
- adjust display and navigation to support `/proc` paths
- allow `cat` and `bash` to read/execute event handlers
- add helper methods to list and interact with `/proc` entries
- test new behaviour

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pip install --quiet selenium pyvirtualdisplay requests ipwhois`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855bb6c36a4832e945828226e8210a5