### PR TITLE
Refactor DojoUtil into its own module

### DIFF
--- a/libs/quickdetect/DojoUtil.py
+++ b/libs/quickdetect/DojoUtil.py
@@ -1,0 +1,28 @@
+class DojoUtil:
+    def __init__(self, webdriver):
+        self.version = 2.0
+        self.beta = True
+        self.webdriver = webdriver
+
+    def is_dojo(self):
+        try:
+            result = self.webdriver.execute_script('return this.dojo.version')
+            if result is None:
+                return False
+            return True
+        except Exception:
+            pass
+        return False
+
+    def getVersionString(self):
+        try:
+            result = self.webdriver.execute_script('return this.dojo.version')
+            return '%d.%d.%d.%d' % (
+                result['major'],
+                result['minor'],
+                result['patch'],
+                result['revision'],
+            )
+        except Exception:
+            pass
+        return None

--- a/libs/quickdetect/QuickDetect.py
+++ b/libs/quickdetect/QuickDetect.py
@@ -11,6 +11,7 @@ from libs.quickdetect.MXEmailUtil import MXEmailUtil
 from libs.quickdetect.WindowNameUtil import WindowNameUtil
 from libs.quickdetect.OnMessageUtil import OnMessageUtil
 from libs.quickdetect.ServiceWorkerUtil import ServiceWorkerUtil
+from libs.quickdetect.DojoUtil import DojoUtil
 
 class QuickDetect:
     def __init__(self, screen, webdriver, curses_util, logger):
@@ -216,26 +217,3 @@ class QuickDetect:
 
 
 
-class DojoUtil:
-    def __init__(self, webdriver):
-        self.version = 2.0
-        self.beta = True
-        self.webdriver = webdriver
-        
-    def is_dojo(self):
-        try:
-            result = self.webdriver.execute_script('return this.dojo.version')
-            if result == None:
-                return False
-            return True
-        except:
-            pass
-        return False
-        
-    def getVersionString(self):
-        try:
-            result = self.webdriver.execute_script('return this.dojo.version')
-            return '%d.%d.%d.%d'%(result['major'], result['minor'], result['patch'], result['revision'])
-        except:
-            pass
-        return None

--- a/libs/quickdetect/__init__.py
+++ b/libs/quickdetect/__init__.py
@@ -1,0 +1,1 @@
+from .DojoUtil import DojoUtil


### PR DESCRIPTION
## Summary
- separate DojoUtil class into `libs/quickdetect/DojoUtil.py`
- import the new module from `QuickDetect`
- export `DojoUtil` from the package

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855bf0fb2b8832ea375d9ba23ea4640