### PR TITLE
Refactor followme state management

### DIFF
--- a/libs/followme/followmecommands.py
+++ b/libs/followme/followmecommands.py
@@ -2,10 +2,6 @@ import time
 import _thread
 from libs.utils.WebDriverUtil import *
 
-paused = False
-run_thread = True
-running_browsers = []
-
 class FollowmeCommands:
     def __init__(self, webdriver, debug, proxy_host, proxy_port, logger):
         self.version = 2.0
@@ -14,35 +10,33 @@ class FollowmeCommands:
         self.proxy_host = proxy_host
         self.proxy_port = proxy_port
         self.logger = logger
+        self.paused = False
+        self.run_thread = True
+        self.running_browsers = []
     
     def start_new_instance(self):
-        global run_thread
-        global running_browsers
-        run_thread = True
+        self.run_thread = True
         browser = self.create_browser_instance()
-        running_browsers.append(browser)
-        newthread = _thread.start_new_thread(self.linkbrowsers, (self.driver, browser))
+        self.running_browsers.append(browser)
+        _thread.start_new_thread(self.linkbrowsers, (self.driver, browser))
         
         
     def pause_all(self):
-        global paused
-        paused = True
+        self.paused = True
 
     def resume_all(self):
-        global paused
-        paused = False
+        self.paused = False
 
     def kill_all(self):
-        global run_thread
-        global running_browsers
-        run_thread = False
-        for x in running_browsers:
-            x.quit()
+        self.run_thread = False
+        for browser in self.running_browsers:
+            browser.quit()
+        self.running_browsers = []
         
 
         
     def get_paused(self):
-        return paused
+        return self.paused
 
     def create_browser_instance(self):
         self.webdriver_util = WebDriverUtil()
@@ -53,10 +47,8 @@ class FollowmeCommands:
             return self.webdriver_util.getDriver(self.logger)
 
     def linkbrowsers(self, maindriver, followmedriver):
-        global paused
-        global run_thread
-        while(run_thread):
-            if(paused == False):
+        while self.run_thread:
+            if not self.paused:
                 try:
                     main_url = maindriver.current_url
                     if followmedriver.current_url != main_url:

--- a/libs/followme/followmemenu.py
+++ b/libs/followme/followmemenu.py
@@ -1,8 +1,6 @@
 import time
 from libs.followme.followmecommands import *
 
-followme_count = 0
-
 class FollowmeScreen:
     def __init__(self, screen, webdriver, curses_util, debug, proxy_host, proxy_port, logger):
         self.version = 2.0
@@ -15,16 +13,16 @@ class FollowmeScreen:
         self.proxy_port = proxy_port
         self.logger = logger
         self.commands = FollowmeCommands(self.driver, self.debug, self.proxy_host, self.proxy_port, self.logger)
+        self.followme_count = 0
         
         
     def run(self):
-        showscreen = True       
-        global followme_count
+        showscreen = True
         
         while showscreen:
             paused = self.commands.get_paused()
             self.screen = self.curses_util.get_screen()
-            self.screen.addstr(11, 2, "Followme running instances: "+str(followme_count))
+            self.screen.addstr(11, 2, "Followme running instances: "+str(self.followme_count))
             self.screen.addstr(4,  4, "1) Start new follow me")
             if paused == False:
                 self.screen.addstr(6,  4, "2) PAUSE follow me")
@@ -43,7 +41,7 @@ class FollowmeScreen:
             if c == ord('1'):
                 try:
                     self.commands.start_new_instance()
-                    followme_count+=1
+                    self.followme_count += 1
                 except:
                     print("ERROR")
                     self.logger.log("EEE - error at start new followme instance")
@@ -57,7 +55,7 @@ class FollowmeScreen:
             
             if c == ord('4'):
                 self.commands.kill_all()
-                followme_count=0
+                self.followme_count = 0
                                                 
         return
         


### PR DESCRIPTION
## Summary
- manage followme state inside FollowmeCommands
- manage count of running followme browsers inside FollowmeScreen
- drop module-level globals for easier instancing

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'selenium')*

------
https://chatgpt.com/codex/tasks/task_e_6855c909e64c832e8abbd9fe29f746fc