### PR TITLE
Refactor screens with menu helper

### DIFF
--- a/libs/angular/angularmenu.py
+++ b/libs/angular/angularmenu.py
@@ -1,5 +1,6 @@
 import curses
 from libs.angular.angularCommands import *
+from libs.utils import MenuHelper
 
 class AngularScreen:
     def __init__(self, screen, webdriver, curses_util, jsinjector):
@@ -13,55 +14,17 @@ class AngularScreen:
         
         
     def show(self):
-        showscreen = True
-        
-        while showscreen:
-            self.screen = self.curses_util.get_screen()
-            self.screen.addstr(2, 2, "AngularJS Tools")
-            
-            self.screen.addstr(4,  4, "1) Show Main Application Name")
-            self.screen.addstr(5,  4, "2) Show Routes")
-            self.screen.addstr(6,  4, "3) Show Dependencies")
-            self.screen.addstr(7,  4, "4) Show Main Classes")
-            self.screen.addstr(8,  4, "5) Show All Classes")
-            self.screen.addstr(9,  4, "6) Test classes relying on ngResource")
-            self.screen.addstr(10, 4, "7) Test classes with get() and query()")
-                
-            self.screen.addstr(22, 28, "PRESS M FOR MAIN MENU")
-            self.screen.refresh()
-            
-            c = self.screen.getch()
-            if c == ord('M') or c == ord('m'):
-                showscreen=False
-                
-            if c == ord('1'):
-                self.curses_util.close_screen()
-                self.commands.show_app_name()
-            
-            if c == ord('2'):
-                self.curses_util.close_screen()
-                self.commands.show_routes()
-            
-            if c == ord('3'):
-                self.curses_util.close_screen()
-                self.commands.show_deps()
-                
-            if c == ord('4'):
-                self.curses_util.close_screen()
-                self.commands.show_main_classes()
-                
-            if c == ord('5'):
-                self.curses_util.close_screen()
-                self.commands.show_all_classes()
-                
-            if c == ord('6'):
-                self.curses_util.close_screen()
-                self.commands.show_ngResource_tests()
+        items = [
+            ('1', "Show Main Application Name", self.commands.show_app_name),
+            ('2', "Show Routes", self.commands.show_routes),
+            ('3', "Show Dependencies", self.commands.show_deps),
+            ('4', "Show Main Classes", self.commands.show_main_classes),
+            ('5', "Show All Classes", self.commands.show_all_classes),
+            ('6', "Test classes relying on ngResource", self.commands.show_ngResource_tests),
+            ('7', "Test classes with get() and query()", self.commands.show_http_tests),
+        ]
 
-            if c == ord('7'):
-                self.curses_util.close_screen()
-                self.commands.show_http_tests()
-                
+        MenuHelper.run(self.curses_util, "AngularJS Tools", items)
         return
         
     

--- a/libs/aws/awsmenu.py
+++ b/libs/aws/awsmenu.py
@@ -2,6 +2,7 @@ import curses
 from selenium.common.exceptions import WebDriverException
 
 from libs.aws.awscommands import *
+from libs.utils import MenuHelper
 
 class AWSScreen:
     def __init__(self, screen, webdriver, curses_util, logger):
@@ -13,26 +14,11 @@ class AWSScreen:
         self.commands = AWSCommands(self.driver, self.logger)
         
         
+        
+
     def show(self):
-        showscreen = True
-        
-        while showscreen:
-            self.screen = self.curses_util.get_screen()
-            self.screen.addstr(2, 2, "AWS")
-            self.screen.addstr(4, 5, "1) Find S3 Bucket Urls")
-
-
-            
-            self.screen.addstr(22, 28, "PRESS M FOR MAIN MENU")
-            self.screen.refresh()
-            
-            c = self.screen.getch()
-            if c == ord('M') or c == ord('m'):
-                showscreen=False
-                
-            if c == ord('1'):
-                self.curses_util.close_screen()
-                self.commands.show_bucket_report()
-                                
+        items = [
+            ('1', "Find S3 Bucket Urls", self.commands.show_bucket_report),
+        ]
+        MenuHelper.run(self.curses_util, "AWS", items)
         return
-        

--- a/libs/brutelogin/bruteloginmenu.py
+++ b/libs/brutelogin/bruteloginmenu.py
@@ -2,6 +2,7 @@ import curses
 from selenium.common.exceptions import WebDriverException
 
 from libs.brutelogin.brutelogincommands import *
+from libs.utils import MenuHelper
 
 class BruteLoginScreen:
     def __init__(self, screen, webdriver, curses_util):
@@ -12,26 +13,10 @@ class BruteLoginScreen:
         self.commands = BruteLoginCommands(self.driver)
         
         
+
     def show(self):
-        showscreen = True
-        
-        while showscreen:
-            self.screen = self.curses_util.get_screen()
-            self.screen.addstr(2, 2, "Brute Force Login")
-            self.screen.addstr(4, 5, "1) Start brute forcing")
-
-
-            
-            self.screen.addstr(22, 28, "PRESS M FOR MAIN MENU")
-            self.screen.refresh()
-            
-            c = self.screen.getch()
-            if c == ord('M') or c == ord('m'):
-                showscreen=False
-                
-            if c == ord('1'):
-                self.curses_util.close_screen()
-                self.commands.start_brute_force()
-                                
+        items = [
+            ('1', "Start brute forcing", self.commands.start_brute_force),
+        ]
+        MenuHelper.run(self.curses_util, "Brute Force Login", items)
         return
-        

--- a/libs/cms/cmsmenu.py
+++ b/libs/cms/cmsmenu.py
@@ -1,5 +1,6 @@
 import curses
 from libs.cms.cmscommands import CMSCommands
+from libs.utils import MenuHelper
 
 
 class CMSScreen:
@@ -11,28 +12,10 @@ class CMSScreen:
         self.logger = logger
 
     def show(self):
-        showscreen = True
-        while showscreen:
-            self.screen = self.curses_util.get_screen()
-            self.screen.addstr(2, 2, "CMS Information")
-            self.screen.addstr(4, 5, "1) WordPress")
-            self.screen.addstr(5, 5, "2) Drupal")
-            self.screen.addstr(6, 5, "3) Sitecore")
-            self.screen.addstr(22, 28, "PRESS M FOR MAIN MENU")
-            self.screen.refresh()
-            c = self.screen.getch()
-            if c in (ord('M'), ord('m')):
-                showscreen = False
-            elif c == ord('1'):
-                self.curses_util.close_screen()
-                self.logger.log('CMS menu: selected WordPress')
-                CMSCommands(self.driver, 'wordpress', self.curses_util, self.logger).show()
-            elif c == ord('2'):
-                self.curses_util.close_screen()
-                self.logger.log('CMS menu: selected Drupal')
-                CMSCommands(self.driver, 'drupal', self.curses_util, self.logger).show()
-            elif c == ord('3'):
-                self.curses_util.close_screen()
-                self.logger.log('CMS menu: selected Sitecore')
-                CMSCommands(self.driver, 'sitecore', self.curses_util, self.logger).show()
+        items = [
+            ('1', 'WordPress', lambda: CMSCommands(self.driver, 'wordpress', self.curses_util, self.logger).show()),
+            ('2', 'Drupal', lambda: CMSCommands(self.driver, 'drupal', self.curses_util, self.logger).show()),
+            ('3', 'Sitecore', lambda: CMSCommands(self.driver, 'sitecore', self.curses_util, self.logger).show()),
+        ]
+        MenuHelper.run(self.curses_util, "CMS Information", items)
         return

--- a/libs/htmltools/htmlmenu.py
+++ b/libs/htmltools/htmlmenu.py
@@ -2,6 +2,7 @@ import curses
 from selenium.common.exceptions import WebDriverException
 from libs.htmltools.htmlcommands import *
 from libs.htmltools.htmltoolsscript import *
+from libs.utils import MenuHelper
 
 class HTMLScreen:
     def __init__(self, screen, webdriver, curses_util, jsinjector):
@@ -15,57 +16,20 @@ class HTMLScreen:
         self.commands = HTMLCommands(self.driver, self.jsinjector)
         
         
+        
+    
+        
+    
+
     def show(self):
-        showscreen = True
-        
-        while showscreen:
-            self.screen = self.curses_util.get_screen()
-            self.screen.addstr(2, 2, "HTML Tools")
-            self.screen.addstr(4, 5, "1) Show hidden form elements") # good demo url for this.... https://www.wufoo.com/html5/types/11-hidden.html
-            self.screen.addstr(5, 5, "2) Turn password fields into text") 
-            self.screen.addstr(6, 5, "3) Turn css visibility on for all HTML elements") 
-            self.screen.addstr(7, 5, "4) Click every element on the page") 
-            self.screen.addstr(8, 5, "5) Type 'test' into every text box")
-            self.screen.addstr(9, 5, "6) Removes hidden & hide from classnames")
-            self.screen.addstr(10, 5,"7) Show all modals  (modal fade -> modal fade show)")
-
-
-            
-            self.screen.addstr(22, 28, "PRESS M FOR MAIN MENU")
-            self.screen.refresh()
-            
-            c = self.screen.getch()
-            if c == ord('M') or c == ord('m'):
-                showscreen=False
-                
-            if c == ord('1'):
-                self.curses_util.close_screen()
-                self.commands.show_hidden_form_elements()
-                
-            if c == ord('2'):
-                self.curses_util.close_screen()
-                self.commands.show_password_fields_as_text()
-                
-            if c == ord('3'):
-                self.curses_util.close_screen()
-                self.commands.see_all_html_elements()
-
-            if c == ord('4'):
-                self.curses_util.close_screen()
-                self.commands.click_everything()
-
-            if c == ord('5'):
-                self.curses_util.close_screen()
-                self.commands.type_into_everything()
-            if c == ord('6'):
-                self.curses_util.close_screen()
-                self.commands.remove_hidden_from_classnames()
-            if c == ord('7'):
-                self.curses_util.close_screen()
-                self.commands.show_modals()
-                                
+        items = [
+            ('1', "Show hidden form elements", self.commands.show_hidden_form_elements),
+            ('2', "Turn password fields into text", self.commands.show_password_fields_as_text),
+            ('3', "Turn css visibility on for all HTML elements", self.commands.see_all_html_elements),
+            ('4', "Click every element on the page", self.commands.click_everything),
+            ('5', "Type 'test' into every text box", self.commands.type_into_everything),
+            ('6', "Removes hidden & hide from classnames", self.commands.remove_hidden_from_classnames),
+            ('7', "Show all modals  (modal fade -> modal fade show)", self.commands.show_modals),
+        ]
+        MenuHelper.run(self.curses_util, "HTML Tools", items)
         return
-        
-    
-        
-    

--- a/libs/javascript/javascriptmenu.py
+++ b/libs/javascript/javascriptmenu.py
@@ -2,6 +2,7 @@ import curses
 from selenium.common.exceptions import WebDriverException
 
 from libs.javascript.javascriptscript import *
+from libs.utils import MenuHelper
 from libs.javascript.javascriptcommands import *
 from libs.javascript.jswalker import *
 from libs.javascript.jsshell import JSShell
@@ -19,61 +20,22 @@ class JavascriptScreen:
         self.jswalker = JSWalker(self.driver, self.jsinjector)
         
         
+
     def show(self):
-        showscreen = True
-        
-        while showscreen:
-            self.screen = self.curses_util.get_screen()
-            self.screen.addstr(2, 2, "Javascript Tools")
-            self.screen.addstr(4, 5, "1) Find URLS within Javascript Global Properties")
-            self.screen.addstr(5, 5, "2) Show Javascript functions of Document")
-            self.screen.addstr(6, 5, "3) Run all js functions without args")
-            self.screen.addstr(7, 5, "4) Show Cookies accessable by Javascript")
-            self.screen.addstr(8, 5, "5) Walk Javascript Functions")
-            self.screen.addstr(9, 5, "6) Javascript Shell")
-            self.screen.addstr(10, 5, "7) Update builtin object list")
+        items = [
+            ('1', "Find URLS within Javascript Global Properties", self.commands.search_for_urls),
+            ('2', "Show Javascript functions of Document", self.commands.search_for_document_javascript_methods),
+            ('3', "Run all js functions without args", self.commands.run_lone_javascript_functions),
+            ('4', "Show Cookies accessable by Javascript", self.commands.show_cookies),
+            ('5', "Walk Javascript Functions", self.jswalker.start_walk_tree),
+            ('6', "Javascript Shell", self._run_shell),
+            ('7', "Update builtin object list", self.commands.dump_browser_objects),
+        ]
+        MenuHelper.run(self.curses_util, "Javascript Tools", items)
 
-
-            
-            self.screen.addstr(22, 28, "PRESS M FOR MAIN MENU")
-            self.screen.refresh()
-            
-            c = self.screen.getch()
-            if c == ord('M') or c == ord('m'):
-                showscreen=False
-                
-            if c == ord('1'):
-                self.curses_util.close_screen()
-                self.commands.search_for_urls()
-                
-            if c == ord('2'):
-                self.curses_util.close_screen()
-                self.commands.search_for_document_javascript_methods()
-
-            if c == ord('3'):
-                self.curses_util.close_screen()
-                self.commands.run_lone_javascript_functions()
-
-            if c == ord('4'):
-                self.curses_util.close_screen()
-                self.commands.show_cookies()
-
-            if c == ord('5'):
-                self.curses_util.close_screen()
-                self.jswalker.start_walk_tree()
-                #self.commands.walk_functions()
-
-            if c == ord('6'):
-                self.curses_util.close_screen()
-                if self.driver == 'notset':
-                    print("Javascript Shell requires a loaded page. Use GOTO to open a URL first.")
-                    input("Press ENTER to continue...")
-                else:
-                    JSShell(self.driver, self.url_callback).run()
-
-            if c == ord('7'):
-                self.curses_util.close_screen()
-                self.commands.dump_browser_objects()
-
-        return
-        
+    def _run_shell(self):
+        if self.driver == 'notset':
+            print("Javascript Shell requires a loaded page. Use GOTO to open a URL first.")
+            input("Press ENTER to continue...")
+        else:
+            JSShell(self.driver, self.url_callback).run()

--- a/libs/spider/spiderscreen.py
+++ b/libs/spider/spiderscreen.py
@@ -1,5 +1,6 @@
 import curses
 from libs.spider.spidercommands import *
+from libs.utils import MenuHelper
 
 class SpiderScreen:
     def __init__(self, screen, curses_util, webdriver):
@@ -12,40 +13,31 @@ class SpiderScreen:
         
     def show(self, currenturl):
         self.current_url = currenturl
-        showscreen = True
-        
-        while showscreen:
-            self.screen = self.curses_util.get_screen()
-            self.screen.addstr(2, 2, "Spider Tools")
-            
-            self.screen.addstr(4, 4, "1) Set Url to spider")
-            self.screen.addstr(5, 24, "URL: "+self.current_url)
-            self.screen.addstr(7, 4, "2) Run Kitchensinks in foreground")
-                
-            self.screen.addstr(22, 28, "PRESS M FOR MAIN MENU")
-            self.screen.refresh()
-            
-            c = self.screen.getch()
-            if c == ord('M') or c == ord('m'):
-                showscreen=False
-                
-            if c == ord('1'):
-                self.current_url = self.curses_util.get_param("Enter the url to spider")
-                if self.current_url[-1] != '/':
-                    self.current_url = self.current_url + '/'
-            
-            if c == ord('2'):
-                self.curses_util.close_screen()
-                try:
-                    self.commands.run_kitchensinks_in_foreground(self.current_url)
-                except:
-                    print("meh")
-                    pass
-            
-                
-                
+
+        def build_items():
+            return [
+                ('1', "Set Url to spider", self._set_url),
+                ('2', "Run Kitchensinks in foreground", self._run_kitchensinks),
+            ]
+
+        def draw(screen):
+            screen.addstr(4, 4, "1) Set Url to spider")
+            screen.addstr(5, 24, "URL: " + self.current_url)
+            screen.addstr(7, 4, "2) Run Kitchensinks in foreground")
+            return 9  # next line
+
+        MenuHelper.run(self.curses_util, "Spider Tools", build_items, extra_draw=lambda s: draw(s))
         return
-        
-    
-        
-    
+
+    def _set_url(self):
+        self.current_url = self.curses_util.get_param("Enter the url to spider")
+        if self.current_url and self.current_url[-1] != '/':
+            self.current_url += '/'
+
+    def _run_kitchensinks(self):
+        try:
+            self.commands.run_kitchensinks_in_foreground(self.current_url)
+        except Exception:
+            print("meh")
+            pass
+

--- a/libs/utils/__init__.py
+++ b/libs/utils/__init__.py
@@ -1,0 +1,1 @@
+from .menuhelper import MenuHelper

--- a/libs/utils/menuhelper.py
+++ b/libs/utils/menuhelper.py
@@ -1,0 +1,40 @@
+class MenuHelper:
+    @staticmethod
+    def run(curses_util, title, items, extra_draw=None):
+        """Display a simple curses menu.
+
+        Parameters
+        ----------
+        curses_util: CursesUtil instance used to manage the screen.
+        title: str title displayed at the top of the screen.
+        items: list or callable returning list of (key, description, callback).
+        extra_draw: optional function(screen) to draw additional content each
+            loop before the items are rendered. It should return the next line
+            number to use for rendering items or None to start at line 4.
+        """
+        showscreen = True
+        while showscreen:
+            screen = curses_util.get_screen()
+            screen.addstr(2, 2, title)
+            line = 4
+            if extra_draw:
+                res = extra_draw(screen)
+                if isinstance(res, int):
+                    line = res
+            current_items = items() if callable(items) else items
+            for key, desc, _ in current_items:
+                screen.addstr(line, 4, f"{key}) {desc}")
+                line += 1
+            screen.addstr(22, 28, "PRESS M FOR MAIN MENU")
+            screen.refresh()
+            c = screen.getch()
+            if c in (ord('M'), ord('m')):
+                showscreen = False
+                continue
+            for key, _, callback in current_items:
+                key_code = key if isinstance(key, int) else ord(str(key))
+                if c == key_code:
+                    curses_util.close_screen()
+                    callback()
+                    break
+

--- a/libs/xss/xssmenu.py
+++ b/libs/xss/xssmenu.py
@@ -1,5 +1,6 @@
 import curses
 from selenium.common.exceptions import WebDriverException
+from libs.utils import MenuHelper
 
 from libs.xss.xsscommands import *
 
@@ -13,44 +14,25 @@ class XSSScreen:
         self.commands = XSSCommands(self.driver, self.logger)
         
         
+        
+
     def show(self):
-        showscreen = True
-        
-        while showscreen:
-            self.screen = self.curses_util.get_screen()
-            self.screen.addstr(2, 2, "XSS")
-            self.screen.addstr(4, 5, "1) Find XSS")
-            self.screen.addstr(5, 5, "2) Create window.name exploit")
-            self.screen.addstr(6, 5, "3) Test postMessage")
+        def get_payload():
+            try:
+                return input("Enter XSS payload (default alert): ") or None
+            except KeyboardInterrupt:
+                return None
 
+        def get_message():
+            try:
+                return input("Enter postMessage payload: ") or "test"
+            except KeyboardInterrupt:
+                return "test"
 
-            
-            self.screen.addstr(22, 28, "PRESS M FOR MAIN MENU")
-            self.screen.refresh()
-            
-            c = self.screen.getch()
-            if c == ord('M') or c == ord('m'):
-                showscreen=False
-                
-            if c == ord('1'):
-                self.curses_util.close_screen()
-                self.commands.find_xss()
-
-            if c == ord('2'):
-                self.curses_util.close_screen()
-                try:
-                    payload = input("Enter XSS payload (default alert): ") or None
-                except KeyboardInterrupt:
-                    payload = None
-                self.commands.create_window_name_exploit(payload)
-
-            if c == ord('3'):
-                self.curses_util.close_screen()
-                try:
-                    message = input("Enter postMessage payload: ") or "test"
-                except KeyboardInterrupt:
-                    message = "test"
-                self.commands.test_post_message(message)
-                                
+        items = [
+            ('1', "Find XSS", self.commands.find_xss),
+            ('2', "Create window.name exploit", lambda: self.commands.create_window_name_exploit(get_payload())),
+            ('3', "Test postMessage", lambda: self.commands.test_post_message(get_message())),
+        ]
+        MenuHelper.run(self.curses_util, "XSS", items)
         return
-        


### PR DESCRIPTION
## Summary
- centralize curses menu logic in `MenuHelper`
- simplify screen classes to use the helper
- expose `MenuHelper` from utils

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'selenium')*

------
https://chatgpt.com/codex/tasks/task_e_6855c9f342c4832e93da883047042e22