### PR TITLE
Handle virtual display cleanup

### DIFF
--- a/libs/mainmenu/mainframe.py
+++ b/libs/mainmenu/mainframe.py
@@ -167,6 +167,14 @@ class mainframe:
                 self.logger.error("Unexpected error!")
                 raise
         self.curses_util.close_screen()
+        if self.driver != 'notset':
+            try:
+                if hasattr(self, 'webdriver_util'):
+                    self.webdriver_util.quit_driver(self.driver)
+                else:
+                    self.driver.quit()
+            except Exception:
+                pass
     def create_browser_instance(self):
         self.webdriver_util = WebDriverUtil()
         self.webdriver_util.setDebug(self.debug)
@@ -198,6 +206,14 @@ class mainframe:
     def update_and_restart(self):
         """Pull latest updates from git and restart the application."""
         self.curses_util.close_screen()
+        if self.driver != 'notset':
+            try:
+                if hasattr(self, 'webdriver_util'):
+                    self.webdriver_util.quit_driver(self.driver)
+                else:
+                    self.driver.quit()
+            except Exception:
+                pass
         result = subprocess.run(['git', 'pull'], capture_output=True, text=True)
         self.logger.log(result.stdout)
         if 'Already up to date.' in result.stdout:

--- a/libs/utils/WebDriverUtil.py
+++ b/libs/utils/WebDriverUtil.py
@@ -11,6 +11,7 @@ class WebDriverUtil:
         self.version = 2.0
         self.beta = True
         self.debug = False
+        self.display = None
         
     def setDebug(self, newValue):
         self.debug = newValue
@@ -39,7 +40,7 @@ class WebDriverUtil:
         return driver
         
         
-    def getDriver(self, logger):        
+    def getDriver(self, logger):
         webnuke_config_proxy_port = 33333
         webnuke_config_web_api_port = 44444
         webnuke_config_web_api_url = 'http://localhost:'+str(webnuke_config_web_api_port)
@@ -48,6 +49,21 @@ class WebDriverUtil:
         chrome_options.add_argument("--ignore-certificate-errors")
         driver = Chrome(options=chrome_options)
         return driver
+
+    def stop_display(self):
+        """Stop the X virtual display if it was started."""
+        if self.display is not None:
+            try:
+                self.display.stop()
+            finally:
+                self.display = None
+
+    def quit_driver(self, driver):
+        """Quit the given webdriver and stop the display."""
+        try:
+            driver.quit()
+        finally:
+            self.stop_display()
         
 
 


### PR DESCRIPTION
## Summary
- ensure `WebDriverUtil` tracks the display object
- add `stop_display` and `quit_driver` helpers
- clean up the webdriver and display when quitting or updating in `mainframe`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855d0a2a34c832e99a80f58e9ff3eb8