### PR TITLE
Add Vue.js detection support

### DIFF
--- a/libs/quickdetect/QuickDetect.py
+++ b/libs/quickdetect/QuickDetect.py
@@ -13,6 +13,7 @@ from libs.quickdetect.OnMessageUtil import OnMessageUtil
 from libs.quickdetect.ServiceWorkerUtil import ServiceWorkerUtil
 from libs.quickdetect.DojoUtil import DojoUtil
 from libs.quickdetect.ReactUtil import ReactUtil
+from libs.quickdetect.VueUtil import VueUtil
 
 class QuickDetect:
     def __init__(self, screen, webdriver, curses_util, logger):
@@ -35,6 +36,12 @@ class QuickDetect:
         react_version = None
         if is_react:
             react_version = react_util.get_version_string()
+
+        vue_util = VueUtil(self.driver)
+        is_vue = vue_util.is_vue()
+        vue_version = None
+        if is_vue:
+            vue_version = vue_util.get_version_string()
         
         wordpress_util = WordPressUtil(self.driver)
         isWordpress = wordpress_util.isWordPress()
@@ -123,6 +130,13 @@ class QuickDetect:
                 message = "React Detected"
                 if react_version is not None:
                     message += " ("+react_version+")"
+                self.screen.addstr(current_line, 4, message, curses.color_pair(2))
+                current_line += 1
+
+            if is_vue:
+                message = "Vue.js Detected"
+                if vue_version is not None:
+                    message += " ("+vue_version+")"
                 self.screen.addstr(current_line, 4, message, curses.color_pair(2))
                 current_line += 1
                 

--- a/libs/quickdetect/VueUtil.py
+++ b/libs/quickdetect/VueUtil.py
@@ -1,0 +1,24 @@
+from selenium.webdriver.remote.webdriver import WebDriver
+from libs.utils.logger import FileLogger
+
+class VueUtil:
+    def __init__(self, webdriver: WebDriver, logger=None):
+        self.webdriver = webdriver
+        self.logger = logger or FileLogger()
+
+    def is_vue(self) -> bool:
+        """Return True if Vue is detected on the page."""
+        try:
+            return bool(self.webdriver.execute_script("return typeof Vue !== 'undefined';"))
+        except Exception as e:
+            self.logger.error(f'Error detecting Vue: {e}')
+            return False
+
+    def get_version_string(self):
+        """Return the Vue.js version string if available."""
+        try:
+            script = "return (window.Vue && window.Vue.version) ? window.Vue.version : null;"
+            return self.webdriver.execute_script(script)
+        except Exception as e:
+            self.logger.error(f'Error retrieving Vue version: {e}')
+            return None

--- a/libs/quickdetect/__init__.py
+++ b/libs/quickdetect/__init__.py
@@ -1,2 +1,3 @@
 from .DojoUtil import DojoUtil
 from .ReactUtil import ReactUtil
+from .VueUtil import VueUtil

--- a/tests/test_quickdetect.py
+++ b/tests/test_quickdetect.py
@@ -4,6 +4,7 @@ from libs.quickdetect.DrupalUtil import DrupalUtil
 from libs.quickdetect.WindowNameUtil import WindowNameUtil
 from libs.quickdetect.ServiceWorkerUtil import ServiceWorkerUtil
 from libs.quickdetect.ReactUtil import ReactUtil
+from libs.quickdetect.VueUtil import VueUtil
 from selenium.webdriver.common.by import By
 
 class DummyElement:
@@ -111,6 +112,29 @@ class ReactUtilTests(unittest.TestCase):
         driver = Driver()
         util = ReactUtil(driver)
         self.assertFalse(util.is_react())
+        self.assertIsNone(util.get_version_string())
+
+
+class VueUtilTests(unittest.TestCase):
+    def test_is_vue_positive(self):
+        class Driver(DummyDriver):
+            def execute_script(self, script):
+                if 'typeof Vue' in script:
+                    return True
+                if 'window.Vue && window.Vue.version' in script:
+                    return '3.2.0'
+        driver = Driver()
+        util = VueUtil(driver)
+        self.assertTrue(util.is_vue())
+        self.assertEqual(util.get_version_string(), '3.2.0')
+
+    def test_is_vue_negative(self):
+        class Driver(DummyDriver):
+            def execute_script(self, script):
+                return None
+        driver = Driver()
+        util = VueUtil(driver)
+        self.assertFalse(util.is_vue())
         self.assertIsNone(util.get_version_string())
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- implement `VueUtil` to detect Vue.js
- add Vue detection to QuickDetect output
- expose VueUtil in quickdetect package
- test VueUtil logic alongside other quickdetect utilities

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855d56c0114832eaf40b938486cb28c