### PR TITLE
Add GraphQL detection

### DIFF
--- a/libs/quickdetect/GraphQLUtil.py
+++ b/libs/quickdetect/GraphQLUtil.py
@@ -1,0 +1,34 @@
+from selenium.webdriver.common.by import By
+from libs.utils.logger import FileLogger
+
+class GraphQLUtil:
+    """Utility class to detect GraphQL usage on a webpage."""
+
+    def __init__(self, webdriver, logger=None):
+        self.webdriver = webdriver
+        self.logger = logger or FileLogger()
+
+    def has_graphql(self) -> bool:
+        """Return True if a GraphQL endpoint is referenced in the DOM or network."""
+        try:
+            scripts = self.webdriver.find_elements(By.XPATH, "//script")
+            for tag in scripts:
+                src = tag.get_attribute("src") or ""
+                if "/graphql" in src.lower():
+                    return True
+                content = tag.get_attribute("innerHTML") or ""
+                if "/graphql" in content.lower():
+                    return True
+        except Exception as e:
+            self.logger.error(f"Error scanning script tags for GraphQL: {e}")
+        try:
+            urls = self.webdriver.execute_script(
+                "return (window.performance && window.performance.getEntries) ? "
+                "window.performance.getEntries().map(e => e.name) : []"
+            )
+            for url in urls or []:
+                if "/graphql" in str(url).lower():
+                    return True
+        except Exception as e:
+            self.logger.error(f"Error retrieving performance entries: {e}")
+        return False

--- a/libs/quickdetect/QuickDetect.py
+++ b/libs/quickdetect/QuickDetect.py
@@ -14,6 +14,7 @@ from libs.quickdetect.ServiceWorkerUtil import ServiceWorkerUtil
 from libs.quickdetect.DojoUtil import DojoUtil
 from libs.quickdetect.ReactUtil import ReactUtil
 from libs.quickdetect.VueUtil import VueUtil
+from libs.quickdetect.GraphQLUtil import GraphQLUtil
 
 class QuickDetect:
     def __init__(self, screen, webdriver, curses_util, logger):
@@ -42,6 +43,9 @@ class QuickDetect:
         vue_version = None
         if is_vue:
             vue_version = vue_util.get_version_string()
+
+        graphql_util = GraphQLUtil(self.driver, self.logger)
+        has_graphql = graphql_util.has_graphql()
         
         wordpress_util = WordPressUtil(self.driver)
         isWordpress = wordpress_util.isWordPress()
@@ -137,6 +141,11 @@ class QuickDetect:
                 message = "Vue.js Detected"
                 if vue_version is not None:
                     message += " ("+vue_version+")"
+                self.screen.addstr(current_line, 4, message, curses.color_pair(2))
+                current_line += 1
+
+            if has_graphql:
+                message = "GraphQL Detected"
                 self.screen.addstr(current_line, 4, message, curses.color_pair(2))
                 current_line += 1
                 

--- a/libs/quickdetect/__init__.py
+++ b/libs/quickdetect/__init__.py
@@ -1,3 +1,4 @@
 from .DojoUtil import DojoUtil
 from .ReactUtil import ReactUtil
 from .VueUtil import VueUtil
+from .GraphQLUtil import GraphQLUtil

--- a/tests/test_quickdetect.py
+++ b/tests/test_quickdetect.py
@@ -5,6 +5,7 @@ from libs.quickdetect.WindowNameUtil import WindowNameUtil
 from libs.quickdetect.ServiceWorkerUtil import ServiceWorkerUtil
 from libs.quickdetect.ReactUtil import ReactUtil
 from libs.quickdetect.VueUtil import VueUtil
+from libs.quickdetect.GraphQLUtil import GraphQLUtil
 from selenium.webdriver.common.by import By
 
 class DummyElement:
@@ -136,6 +137,53 @@ class VueUtilTests(unittest.TestCase):
         util = VueUtil(driver)
         self.assertFalse(util.is_vue())
         self.assertIsNone(util.get_version_string())
+
+
+class GraphQLUtilTests(unittest.TestCase):
+    def test_has_graphql_dom(self):
+        class Driver(DummyDriver):
+            def __init__(self):
+                super().__init__()
+                self.scripts = [
+                    DummyElement({'src': '/graphql.js'}),
+                ]
+
+            def find_elements(self, by, value):
+                if value == "//script":
+                    return self.scripts
+                return []
+
+        driver = Driver()
+        util = GraphQLUtil(driver)
+        self.assertTrue(util.has_graphql())
+
+    def test_has_graphql_network(self):
+        class Driver(DummyDriver):
+            def __init__(self):
+                super().__init__()
+                self.entries = ['/api/graphql']
+
+            def find_elements(self, by, value):
+                return []
+
+            def execute_script(self, script):
+                return self.entries
+
+        driver = Driver()
+        util = GraphQLUtil(driver)
+        self.assertTrue(util.has_graphql())
+
+    def test_has_graphql_negative(self):
+        class Driver(DummyDriver):
+            def find_elements(self, by, value):
+                return []
+
+            def execute_script(self, script):
+                return []
+
+        driver = Driver()
+        util = GraphQLUtil(driver)
+        self.assertFalse(util.has_graphql())
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- implement GraphQLUtil to detect `/graphql` URLs from DOM and network
- report GraphQL usage in QuickDetect
- add unit tests for new util

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855d62c5f88832eba7285d8701824b2