### PR TITLE
Add CSP detection utility

### DIFF
--- a/libs/quickdetect/CSPUtil.py
+++ b/libs/quickdetect/CSPUtil.py
@@ -1,0 +1,42 @@
+from selenium.webdriver.common.by import By
+from libs.utils.logger import FileLogger
+
+
+class CSPUtil:
+    """Utility to detect Content Security Policy from meta tags or response headers."""
+
+    def __init__(self, webdriver, logger=None):
+        self.webdriver = webdriver
+        self.logger = logger or FileLogger()
+
+    def get_meta_csp(self):
+        """Return the Content-Security-Policy defined in a meta tag if present."""
+        try:
+            elements = self.webdriver.find_elements(By.XPATH, "//meta[@http-equiv='Content-Security-Policy']")
+            for meta in elements:
+                content = meta.get_attribute("content")
+                if content:
+                    return content
+        except Exception as e:
+            self.logger.error(f"Error reading CSP meta tag: {e}")
+        return None
+
+    def get_header_csp(self):
+        """Return the CSP from response headers if available on the driver."""
+        headers = None
+        try:
+            headers = getattr(self.webdriver, "last_response_headers", None)
+            if headers is None:
+                headers = getattr(self.webdriver, "response_headers", None)
+            if headers:
+                for key in ("Content-Security-Policy", "Content-Security-Policy-Report-Only"):
+                    value = headers.get(key)
+                    if value:
+                        return value
+        except Exception as e:
+            self.logger.error(f"Error reading CSP headers: {e}")
+        return None
+
+    def has_csp(self):
+        return bool(self.get_meta_csp() or self.get_header_csp())
+

--- a/libs/quickdetect/QuickDetect.py
+++ b/libs/quickdetect/QuickDetect.py
@@ -15,6 +15,7 @@ from libs.quickdetect.DojoUtil import DojoUtil
 from libs.quickdetect.ReactUtil import ReactUtil
 from libs.quickdetect.VueUtil import VueUtil
 from libs.quickdetect.GraphQLUtil import GraphQLUtil
+from libs.quickdetect.CSPUtil import CSPUtil
 
 class QuickDetect:
     def __init__(self, screen, webdriver, curses_util, logger):
@@ -112,6 +113,9 @@ class QuickDetect:
         sw_supported = sw_util.is_supported()
         sw_registered = sw_util.has_service_worker()
         sw_running = sw_util.is_running() if sw_registered else False
+
+        csp_util = CSPUtil(self.driver, self.logger)
+        has_csp = csp_util.has_csp()
             
             
         showscreen = True
@@ -242,6 +246,11 @@ class QuickDetect:
                     message += " (origin checked)"
                 else:
                     message += " (origin not checked)"
+                self.screen.addstr(current_line, 4, message, curses.color_pair(2))
+                current_line += 1
+
+            if has_csp:
+                message = "Content Security Policy Detected"
                 self.screen.addstr(current_line, 4, message, curses.color_pair(2))
                 current_line += 1
                 

--- a/libs/quickdetect/__init__.py
+++ b/libs/quickdetect/__init__.py
@@ -2,3 +2,4 @@ from .DojoUtil import DojoUtil
 from .ReactUtil import ReactUtil
 from .VueUtil import VueUtil
 from .GraphQLUtil import GraphQLUtil
+from .CSPUtil import CSPUtil

--- a/tests/test_csp.py
+++ b/tests/test_csp.py
@@ -1,0 +1,47 @@
+import unittest
+from libs.quickdetect.CSPUtil import CSPUtil
+from selenium.webdriver.common.by import By
+
+
+class DummyElement:
+    def __init__(self, attrs=None):
+        self.attrs = attrs or {}
+
+    def get_attribute(self, name):
+        return self.attrs.get(name)
+
+
+class DummyDriver:
+    def __init__(self, elements=None, headers=None):
+        self.elements = elements or {}
+        self.last_response_headers = headers or {}
+
+    def find_elements(self, by, value):
+        if value in self.elements:
+            return [DummyElement(self.elements[value])]
+        return []
+
+
+class CSPUtilTests(unittest.TestCase):
+    def test_has_csp_meta(self):
+        elements = {"//meta[@http-equiv='Content-Security-Policy']": {"content": "default-src 'self'"}}
+        driver = DummyDriver(elements)
+        util = CSPUtil(driver)
+        self.assertTrue(util.has_csp())
+        self.assertEqual(util.get_meta_csp(), "default-src 'self'")
+
+    def test_has_csp_header(self):
+        driver = DummyDriver(headers={"Content-Security-Policy": "default-src 'self'"})
+        util = CSPUtil(driver)
+        self.assertTrue(util.has_csp())
+        self.assertEqual(util.get_header_csp(), "default-src 'self'")
+
+    def test_no_csp(self):
+        driver = DummyDriver()
+        util = CSPUtil(driver)
+        self.assertFalse(util.has_csp())
+
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- add `CSPUtil` helper for detecting Content Security Policy
- expose the helper via quickdetect package
- integrate CSP check in `QuickDetect.run()` output
- add unit tests for the new helper

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855d70739f0832ea87cccf65dc6c202