### PR TITLE
Add manifest detection util and tests

### DIFF
--- a/libs/quickdetect/ManifestUtil.py
+++ b/libs/quickdetect/ManifestUtil.py
@@ -1,0 +1,25 @@
+from selenium.webdriver.remote.webdriver import WebDriver
+from selenium.webdriver.common.by import By
+from libs.utils.logger import FileLogger
+
+
+class ManifestUtil:
+    def __init__(self, webdriver: WebDriver, logger=None):
+        self.webdriver = webdriver
+        self.logger = logger or FileLogger()
+
+    def has_manifest(self) -> bool:
+        try:
+            self.webdriver.find_element(By.XPATH, "//link[@rel='manifest']")
+            return True
+        except Exception as e:
+            self.logger.error(f'Error detecting manifest: {e}')
+            return False
+
+    def get_manifest_url(self):
+        try:
+            element = self.webdriver.find_element(By.XPATH, "//link[@rel='manifest']")
+            return element.get_attribute('href')
+        except Exception as e:
+            self.logger.error(f'Error retrieving manifest URL: {e}')
+            return None

--- a/libs/quickdetect/QuickDetect.py
+++ b/libs/quickdetect/QuickDetect.py
@@ -16,6 +16,7 @@ from libs.quickdetect.ReactUtil import ReactUtil
 from libs.quickdetect.VueUtil import VueUtil
 from libs.quickdetect.GraphQLUtil import GraphQLUtil
 from libs.quickdetect.CSPUtil import CSPUtil
+from libs.quickdetect.ManifestUtil import ManifestUtil
 
 class QuickDetect:
     def __init__(self, screen, webdriver, curses_util, logger):
@@ -116,6 +117,10 @@ class QuickDetect:
 
         csp_util = CSPUtil(self.driver, self.logger)
         has_csp = csp_util.has_csp()
+
+        manifest_util = ManifestUtil(self.driver, self.logger)
+        has_manifest = manifest_util.has_manifest()
+        manifest_url = manifest_util.get_manifest_url() if has_manifest else None
             
             
         showscreen = True
@@ -251,6 +256,13 @@ class QuickDetect:
 
             if has_csp:
                 message = "Content Security Policy Detected"
+                self.screen.addstr(current_line, 4, message, curses.color_pair(2))
+                current_line += 1
+
+            if has_manifest:
+                message = "Web App Manifest Detected"
+                if manifest_url:
+                    message += f" ({manifest_url})"
                 self.screen.addstr(current_line, 4, message, curses.color_pair(2))
                 current_line += 1
                 

--- a/libs/quickdetect/__init__.py
+++ b/libs/quickdetect/__init__.py
@@ -3,3 +3,4 @@ from .ReactUtil import ReactUtil
 from .VueUtil import VueUtil
 from .GraphQLUtil import GraphQLUtil
 from .CSPUtil import CSPUtil
+from .ManifestUtil import ManifestUtil

--- a/tests/test_quickdetect.py
+++ b/tests/test_quickdetect.py
@@ -6,6 +6,7 @@ from libs.quickdetect.ServiceWorkerUtil import ServiceWorkerUtil
 from libs.quickdetect.ReactUtil import ReactUtil
 from libs.quickdetect.VueUtil import VueUtil
 from libs.quickdetect.GraphQLUtil import GraphQLUtil
+from libs.quickdetect.ManifestUtil import ManifestUtil
 from selenium.webdriver.common.by import By
 
 class DummyElement:
@@ -184,6 +185,20 @@ class GraphQLUtilTests(unittest.TestCase):
         driver = Driver()
         util = GraphQLUtil(driver)
         self.assertFalse(util.has_graphql())
+
+
+class ManifestUtilTests(unittest.TestCase):
+    def test_has_manifest_and_url(self):
+        driver = DummyDriver({'//link[@rel=\'manifest\']': {'href': '/test.webmanifest'}})
+        util = ManifestUtil(driver)
+        self.assertTrue(util.has_manifest())
+        self.assertEqual(util.get_manifest_url(), '/test.webmanifest')
+
+    def test_has_manifest_false(self):
+        driver = DummyDriver()
+        util = ManifestUtil(driver)
+        self.assertFalse(util.has_manifest())
+        self.assertIsNone(util.get_manifest_url())
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- create `ManifestUtil` for locating web app manifest links
- import and use `ManifestUtil` in quick detect runner
- report manifest in quick detect UI
- expose `ManifestUtil` from package
- unit tests for manifest detection

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855d8fd4ccc832eac7638ce335690db