### PR TITLE
Add security header detection

### DIFF
--- a/libs/quickdetect/QuickDetect.py
+++ b/libs/quickdetect/QuickDetect.py
@@ -18,6 +18,7 @@ from libs.quickdetect.GraphQLUtil import GraphQLUtil
 from libs.quickdetect.CSPUtil import CSPUtil
 from libs.quickdetect.ManifestUtil import ManifestUtil
 from libs.quickdetect.WebSocketUtil import WebSocketUtil
+from libs.quickdetect.SecurityHeadersUtil import SecurityHeadersUtil
 
 class QuickDetect:
     def __init__(self, screen, webdriver, curses_util, logger):
@@ -125,6 +126,11 @@ class QuickDetect:
 
         websocket_util = WebSocketUtil(self.driver, self.logger)
         has_websocket = websocket_util.has_websocket()
+
+        security_util = SecurityHeadersUtil(self.driver, self.logger)
+        has_hsts = security_util.has_hsts()
+        has_xfo = security_util.has_x_frame_options()
+        has_xcto = security_util.has_x_content_type_options()
             
             
         showscreen = True
@@ -260,6 +266,21 @@ class QuickDetect:
 
             if has_csp:
                 message = "Content Security Policy Detected"
+                self.screen.addstr(current_line, 4, message, curses.color_pair(2))
+                current_line += 1
+
+            if has_hsts:
+                message = "HSTS Enabled"
+                self.screen.addstr(current_line, 4, message, curses.color_pair(2))
+                current_line += 1
+
+            if has_xfo:
+                message = "X-Frame-Options Set"
+                self.screen.addstr(current_line, 4, message, curses.color_pair(2))
+                current_line += 1
+
+            if has_xcto:
+                message = "X-Content-Type-Options Set"
                 self.screen.addstr(current_line, 4, message, curses.color_pair(2))
                 current_line += 1
 

--- a/libs/quickdetect/SecurityHeadersUtil.py
+++ b/libs/quickdetect/SecurityHeadersUtil.py
@@ -1,0 +1,29 @@
+from libs.utils.logger import FileLogger
+
+class SecurityHeadersUtil:
+    """Utility to inspect common security headers on the response."""
+
+    def __init__(self, webdriver, logger=None):
+        self.webdriver = webdriver
+        self.logger = logger or FileLogger()
+
+    def _get_headers(self):
+        try:
+            headers = getattr(self.webdriver, "last_response_headers", None)
+            if headers is None:
+                headers = getattr(self.webdriver, "response_headers", None)
+            if isinstance(headers, dict):
+                # normalize keys to lower-case for easier lookup
+                return {k.lower(): v for k, v in headers.items()}
+        except Exception as e:
+            self.logger.error(f"Error retrieving response headers: {e}")
+        return {}
+
+    def has_hsts(self) -> bool:
+        return "strict-transport-security" in self._get_headers()
+
+    def has_x_frame_options(self) -> bool:
+        return "x-frame-options" in self._get_headers()
+
+    def has_x_content_type_options(self) -> bool:
+        return "x-content-type-options" in self._get_headers()

--- a/libs/quickdetect/__init__.py
+++ b/libs/quickdetect/__init__.py
@@ -5,3 +5,4 @@ from .GraphQLUtil import GraphQLUtil
 from .CSPUtil import CSPUtil
 from .ManifestUtil import ManifestUtil
 from .WebSocketUtil import WebSocketUtil
+from .SecurityHeadersUtil import SecurityHeadersUtil

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -1,0 +1,33 @@
+import unittest
+from libs.quickdetect.SecurityHeadersUtil import SecurityHeadersUtil
+
+class DummyDriver:
+    def __init__(self, last_headers=None, response_headers=None):
+        if last_headers is not None:
+            self.last_response_headers = last_headers
+        if response_headers is not None:
+            self.response_headers = response_headers
+
+class SecurityHeadersUtilTests(unittest.TestCase):
+    def test_has_hsts(self):
+        driver = DummyDriver(last_headers={"Strict-Transport-Security": "max-age=31536000"})
+        util = SecurityHeadersUtil(driver)
+        self.assertTrue(util.has_hsts())
+        self.assertFalse(util.has_x_frame_options())
+        self.assertFalse(util.has_x_content_type_options())
+
+    def test_header_fallback(self):
+        driver = DummyDriver(response_headers={"X-Frame-Options": "DENY"})
+        util = SecurityHeadersUtil(driver)
+        self.assertTrue(util.has_x_frame_options())
+        self.assertFalse(util.has_hsts())
+
+    def test_no_headers(self):
+        driver = DummyDriver()
+        util = SecurityHeadersUtil(driver)
+        self.assertFalse(util.has_hsts())
+        self.assertFalse(util.has_x_frame_options())
+        self.assertFalse(util.has_x_content_type_options())
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `SecurityHeadersUtil` to inspect response headers
- integrate into `QuickDetect` to detect HSTS, X-Frame-Options, and X-Content-Type-Options
- export util in `__init__`
- test security header utility

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'selenium')*

------
https://chatgpt.com/codex/tasks/task_e_6855dc7d7814832ea5cb4383d9366fb8