### PR TITLE
Improve QuickDetect checks

### DIFF
--- a/libs/quickdetect/DojoUtil.py
+++ b/libs/quickdetect/DojoUtil.py
@@ -6,23 +6,29 @@ class DojoUtil:
 
     def is_dojo(self):
         try:
-            result = self.webdriver.execute_script('return this.dojo.version')
-            if result is None:
-                return False
-            return True
+            script = (
+                "return (window.dojo && window.dojo.version) ? "
+                "window.dojo.version : null;"
+            )
+            result = self.webdriver.execute_script(script)
+            return bool(result)
         except Exception:
-            pass
-        return False
+            return False
 
     def getVersionString(self):
         try:
-            result = self.webdriver.execute_script('return this.dojo.version')
-            return '%d.%d.%d.%d' % (
-                result['major'],
-                result['minor'],
-                result['patch'],
-                result['revision'],
+            script = (
+                "return (window.dojo && window.dojo.version) ? "
+                "window.dojo.version : null;"
             )
+            result = self.webdriver.execute_script(script)
+            if isinstance(result, dict):
+                return "%d.%d.%d.%d" % (
+                    result.get('major', 0),
+                    result.get('minor', 0),
+                    result.get('patch', 0),
+                    result.get('revision', 0),
+                )
         except Exception:
             pass
         return None

--- a/libs/quickdetect/JQueryUtil.py
+++ b/libs/quickdetect/JQueryUtil.py
@@ -10,20 +10,25 @@ class JQueryUtil:
         
     def isJQuery(self):
         try:
-            result = self.webdriver.execute_script('return this.$.fn.jquery')
-            if result == None:
-                return False
-            return True
+            script = (
+                "return (window.jQuery && window.jQuery.fn && "
+                "window.jQuery.fn.jquery) ? window.jQuery.fn.jquery : null;"
+            )
+            result = self.webdriver.execute_script(script)
+            return bool(result)
         except Exception as e:
             self.logger.error(f'Error detecting jQuery: {e}')
-        return False
-        
+            return False
+
     def getVersionString(self):
         try:
-            result = self.webdriver.execute_script('return this.$.fn.jquery')
-            return result
+            script = (
+                "return (window.jQuery && window.jQuery.fn && "
+                "window.jQuery.fn.jquery) ? window.jQuery.fn.jquery : null;"
+            )
+            return self.webdriver.execute_script(script)
         except Exception as e:
             self.logger.error(f'Error retrieving jQuery version: {e}')
-        return None
+            return None
 
 

--- a/libs/quickdetect/ManifestUtil.py
+++ b/libs/quickdetect/ManifestUtil.py
@@ -10,16 +10,17 @@ class ManifestUtil:
 
     def has_manifest(self) -> bool:
         try:
-            self.webdriver.find_element(By.XPATH, "//link[@rel='manifest']")
-            return True
+            elements = self.webdriver.find_elements(By.XPATH, "//link[@rel='manifest']")
+            return bool(elements)
         except Exception as e:
             self.logger.error(f'Error detecting manifest: {e}')
             return False
 
     def get_manifest_url(self):
         try:
-            element = self.webdriver.find_element(By.XPATH, "//link[@rel='manifest']")
-            return element.get_attribute('href')
+            elements = self.webdriver.find_elements(By.XPATH, "//link[@rel='manifest']")
+            if elements:
+                return elements[0].get_attribute('href')
         except Exception as e:
             self.logger.error(f'Error retrieving manifest URL: {e}')
-            return None
+        return None

--- a/tests/test_quickdetect.py
+++ b/tests/test_quickdetect.py
@@ -23,6 +23,10 @@ class DummyDriver:
         if value in self.elements:
             return DummyElement(self.elements[value])
         raise Exception('not found')
+    def find_elements(self, by, value):
+        if value in self.elements:
+            return [DummyElement(self.elements[value])]
+        return []
     def execute_script(self, script):
         return None
 


### PR DESCRIPTION
## Summary
- make jQuery detection safer
- make manifest detection rely on `find_elements`
- improve Dojo detection checks
- update tests for new driver behavior

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855de0eaa14832ea16bcdf1778941ab