### PR TITLE
Add S3 bucket URL reporting

### DIFF
--- a/libs/quickdetect/AWSS3Util.py
+++ b/libs/quickdetect/AWSS3Util.py
@@ -11,60 +11,40 @@ class AWSS3Util:
         self.webdriver = webdriver
         self.start_url = start_url
         self.end_url = self.webdriver.current_url
-        self.known_s3_hosts=['.amazonaws.com']
+        self.known_s3_hosts = ['.amazonaws.com']
         self.logger = logger or FileLogger()
+        self.bucket_urls = []
     
 
     
         
     def hasS3Buckets(self):
-        result = False
+        self.bucket_urls = []
+
+        def scan(xpath: str, attribute: str) -> None:
+            for tag in self.webdriver.find_elements(By.XPATH, xpath):
+                url = tag.get_attribute(attribute)
+                if url:
+                    for s3host in self.known_s3_hosts:
+                        if s3host in url:
+                            self.bucket_urls.append(url)
+                            break
+
         try:
-            metatags = self.webdriver.find_elements(By.XPATH, "//meta")
-            for tag in metatags:
-                contenturl = tag.get_attribute('content')
-                if contenturl:
-                    for s3host in self.known_s3_hosts:
-                        if s3host in contenturl:
-                            result = True
-
-            imgtags = self.webdriver.find_elements(By.XPATH, "//img")
-            for tag in imgtags:
-                contenturl = tag.get_attribute('src')
-                if contenturl:
-                    for s3host in self.known_s3_hosts:
-                        if s3host in contenturl:
-                            result = True
-
-            linktags = self.webdriver.find_elements(By.XPATH, "//link")
-            for tag in linktags:
-                contenturl = tag.get_attribute('href')
-                if contenturl:
-                    for s3host in self.known_s3_hosts:
-                        if s3host in contenturl:
-                            result = True
-
-            scripttags = self.webdriver.find_elements(By.XPATH, "//script")
-            for tag in scripttags:
-                contenturl = tag.get_attribute('src')
-                if contenturl:
-                    for s3host in self.known_s3_hosts:
-                        if s3host in contenturl:
-                            result = True
-
-            atags = self.webdriver.find_elements(By.XPATH, "//a")
-            for tag in atags:
-                contenturl = tag.get_attribute('href')
-                if contenturl:
-                    for s3host in self.known_s3_hosts:
-                        if s3host in contenturl:
-                            result = True
-
+            scan("//meta", "content")
+            scan("//img", "src")
+            scan("//link", "href")
+            scan("//script", "src")
+            scan("//a", "href")
         except Exception:
             self.logger.error("ERRORORORORORO")
             raise
-        return result
+
+        return bool(self.bucket_urls)
         
     def getUrlString(self):
         return "S3 BUCKET"
+
+    def get_bucket_urls(self):
+        return self.bucket_urls
         

--- a/libs/quickdetect/QuickDetect.py
+++ b/libs/quickdetect/QuickDetect.py
@@ -87,9 +87,9 @@ class QuickDetect:
         
         s3util = AWSS3Util(self.driver, self.current_url, self.logger)
         isS3 = s3util.hasS3Buckets()
-        S3 = ''
+        bucket_urls = []
         if isS3:
-            S3 = s3util.getUrlString()
+            bucket_urls = s3util.get_bucket_urls()
 
         email_util = MXEmailUtil(self.current_url, self.logger)
         email_provider = email_util.get_provider()
@@ -213,8 +213,8 @@ class QuickDetect:
             
             if isS3:
                 message = "AWS S3 Bucket Detected"
-                if S3 is not None:
-                    message += " ("+S3+")"
+                if bucket_urls:
+                    message += " (" + ", ".join(bucket_urls) + ")"
                 self.screen.addstr(current_line, 4, message, curses.color_pair(2))
                 current_line += 1
 

--- a/tests/test_s3util.py
+++ b/tests/test_s3util.py
@@ -1,0 +1,39 @@
+import unittest
+from libs.quickdetect.AWSS3Util import AWSS3Util
+from selenium.webdriver.common.by import By
+
+class DummyElement:
+    def __init__(self, attrs=None):
+        self.attrs = attrs or {}
+    def get_attribute(self, name):
+        return self.attrs.get(name)
+
+class DummyDriver:
+    def __init__(self, elements=None):
+        self.elements = elements or {}
+        self.current_url = 'http://example.com/'
+    def find_elements(self, by, value):
+        return self.elements.get(value, [])
+
+class AWSS3UtilTests(unittest.TestCase):
+    def test_collects_bucket_urls(self):
+        elements = {
+            "//meta": [DummyElement({'content': 'http://bucket.amazonaws.com/file'})],
+            "//img": [DummyElement({'src': 'http://example.com/image'})]
+        }
+        driver = DummyDriver(elements)
+        util = AWSS3Util(driver, driver.current_url)
+        self.assertTrue(util.hasS3Buckets())
+        self.assertEqual(util.get_bucket_urls(), ['http://bucket.amazonaws.com/file'])
+
+    def test_no_bucket_urls(self):
+        elements = {
+            "//meta": [DummyElement({'content': 'http://example.com/file'})]
+        }
+        driver = DummyDriver(elements)
+        util = AWSS3Util(driver, driver.current_url)
+        self.assertFalse(util.hasS3Buckets())
+        self.assertEqual(util.get_bucket_urls(), [])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- track bucket URLs in `AWSS3Util`
- expose collected URLs through `get_bucket_urls`
- show bucket URLs in QuickDetect output
- test the new S3 detection logic

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855e6833bf0832ebbc32778c0612cac