### PR TITLE
Handle missing HTML elements in QuickDetect

### DIFF
--- a/libs/quickdetect/DrupalUtil.py
+++ b/libs/quickdetect/DrupalUtil.py
@@ -26,26 +26,13 @@ class DrupalUtil:
         return None
         
     def getMetaGenerator(self):
-        generator = ''
-        
-        found_generator = False
         try:
-            result = self.webdriver.find_element(By.XPATH, "//meta[@name='Generator']")
-            generator = result.get_attribute("content")
-            found_generator = True
+            for xpath in ("//meta[@name='Generator']", "//meta[@name='generator']"):
+                elements = self.webdriver.find_elements(By.XPATH, xpath)
+                if elements:
+                    return elements[0].get_attribute("content")
         except Exception as e:
-            self.logger.error(f'Error reading Generator meta tag: {e}')
-
-        if found_generator == False:
-            try:
-                result = self.webdriver.find_element(By.XPATH, "//meta[@name='generator']")
-                generator = result.get_attribute("content")
-                found_generator = True
-            except Exception as e:
-                self.logger.error(f'Error reading generator tag: {e}')
-        
-        if found_generator:
-            return generator
+            self.logger.error(f'Error reading generator tag: {e}')
         return None
         
 

--- a/libs/quickdetect/WordPressUtil.py
+++ b/libs/quickdetect/WordPressUtil.py
@@ -10,19 +10,20 @@ class WordPressUtil:
         
     def isWordPress(self):
         try:
-            self.webdriver.find_element(By.XPATH, "//meta[@name='generator']")
-            generator = self.getVersionString()
-            if generator and generator.startswith('WordPress'):
-                return True
+            elements = self.webdriver.find_elements(By.XPATH, "//meta[@name='generator']")
+            if elements:
+                generator = self.getVersionString()
+                if generator and generator.startswith('WordPress'):
+                    return True
         except Exception as e:
             self.logger.error(f'Error detecting WordPress: {e}')
         return False
         
     def getVersionString(self):
         try:
-            result = self.webdriver.find_element(By.XPATH, "//meta[@name='generator']")
-            generator = result.get_attribute("content")
-            return generator
+            elements = self.webdriver.find_elements(By.XPATH, "//meta[@name='generator']")
+            if elements:
+                return elements[0].get_attribute("content")
         except Exception as e:
             self.logger.error(f'Error retrieving WordPress version: {e}')
         return None

--- a/quickdetect_cli.py
+++ b/quickdetect_cli.py
@@ -1,7 +1,18 @@
 import argparse
+import curses
 from libs.utils.WebDriverUtil import WebDriverUtil
 from libs.utils.logger import FileLogger
 from libs.quickdetect.QuickDetect import QuickDetect
+
+_orig_color_pair = curses.color_pair
+
+def _safe_color_pair(n: int) -> int:
+    try:
+        return _orig_color_pair(n)
+    except curses.error:
+        return 0
+
+curses.color_pair = _safe_color_pair
 
 
 class DummyScreen:

--- a/tests/test_quickdetect.py
+++ b/tests/test_quickdetect.py
@@ -41,6 +41,12 @@ class WordPressUtilTests(unittest.TestCase):
         util = WordPressUtil(driver)
         self.assertFalse(util.isWordPress())
 
+    def test_is_wordpress_false_when_tag_absent(self):
+        driver = DummyDriver()
+        util = WordPressUtil(driver)
+        self.assertFalse(util.isWordPress())
+        self.assertIsNone(util.getVersionString())
+
 class DrupalUtilTests(unittest.TestCase):
     def test_get_version_string_none_when_no_generator(self):
         driver = DummyDriver()


### PR DESCRIPTION
## Summary
- handle absent elements gracefully in WordPress and Drupal detectors
- patch `curses.color_pair` in the CLI to avoid initialization errors
- add tests for missing WordPress generator tag

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855e994b28c832e9b4a40644e1417e5