### PR TITLE
Add headless browser support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,20 @@ To run:
 ```
 python console.py
 ```
+The console also supports running Chrome in headless mode with the `--headless` flag:
+```
+python console.py --headless https://example.com
+```
 
 ### QuickDetect CLI
 
-Run QuickDetect directly from the command line without the curses interface. Use the optional `--log`/`-l` flag to write results to a file. A screenshot of the target page can also be saved with `--screenshot`/`-s`:
+Run QuickDetect directly from the command line without the curses interface. Use the optional `--log`/`-l` flag to write results to a file. A screenshot of the target page can also be saved with `--screenshot`/`-s`. Use `--headless` to run Chrome without a GUI:
 
 ```bash
 python quickdetect_cli.py https://example.com
 python quickdetect_cli.py https://example.com --log scan.log
 python quickdetect_cli.py https://example.com -s page.png
+python quickdetect_cli.py https://example.com --headless
 ```
 
 ![webnuke main gui](http://bugbound.co.uk/sites/default/files/webnuke%20mainscreen.png?19)

--- a/console.py
+++ b/console.py
@@ -1,26 +1,35 @@
 #!/usr/bin/env python3
 # add owa to quickdetect - look for function IsOwaPremiumBrowser
 
+import argparse
+import traceback
 from libs.utils.logger import *
 from libs.mainmenu.mainframe import *
-import sys
-import traceback
 
-if __name__ == '__main__':
+def main():
+        parser = argparse.ArgumentParser(description="Run Webnuke console")
+        parser.add_argument("url", nargs="?", help="URL to open on startup")
+        parser.add_argument("--headless", action="store_true", help="Run Chrome in headless mode")
+        args = parser.parse_args()
+
         log_file = FileLogger()
         log_file.debug('Webnuke started.')
 
         try:
-                mf = mainframe(log_file)
-                if len(sys.argv) > 1:
-                        mf.open_url(sys.argv[1])
+                mf = mainframe(log_file, headless=args.headless)
+                if args.url:
+                        mf.open_url(args.url)
                 mf.show_main_screen()
-        except Exception as e:
+        except Exception:
                 log_file.error('ERROR RUNNING WEBNUKE.')
                 log_file.error(traceback.format_exc())
                 raise
 
         log_file.debug('Webnuke finished.')
+
+
+if __name__ == '__main__':
+        main()
 
 
 		

--- a/libs/mainmenu/mainframe.py
+++ b/libs/mainmenu/mainframe.py
@@ -22,8 +22,9 @@ import os
 import sys
 
 class mainframe:
-    def __init__(self, logger):
+    def __init__(self, logger, headless=False):
         self.debug = True
+        self.headless = headless
         self.proxy_host = ''
         self.proxy_port = 0
         self.driver = 'notset'
@@ -180,9 +181,9 @@ class mainframe:
         self.webdriver_util.setDebug(self.debug)
         if self.proxy_host != '' and int(self.proxy_port) != 0:
             self.logger.log("getting webdriver with proxy support")
-            return self.webdriver_util.getDriverWithProxySupport(self.proxy_host, int(self.proxy_port))
+            return self.webdriver_util.getDriverWithProxySupport(self.proxy_host, int(self.proxy_port), headless=self.headless)
         else:
-            return self.webdriver_util.getDriver(self.logger)
+            return self.webdriver_util.getDriver(self.logger, headless=self.headless)
          
     def open_url(self, url):
         if not url.startswith(('http://', 'https://')):

--- a/libs/utils/WebDriverUtil.py
+++ b/libs/utils/WebDriverUtil.py
@@ -26,8 +26,8 @@ class WebDriverUtil:
         #profile.set_preference("network.http.use-cache", False)
         return profile
         
-    def getDriverWithProxySupport(self, proxy_host, proxy_port):
-        if self.debug == False:
+    def getDriverWithProxySupport(self, proxy_host, proxy_port, headless=False):
+        if self.debug == False and not headless:
             self.display = Display(visible=0, size=(1920, 1080))
             self.display.start()
         
@@ -37,6 +37,8 @@ class WebDriverUtil:
         chrome_options = webdriver.ChromeOptions()
         chrome_options.add_argument("--proxy-server=%s" % ("http://" + proxy_host + ":" + str(proxy_port)))
         chrome_options.add_argument("--ignore-certificate-errors")
+        if headless:
+            chrome_options.add_argument("--headless")
 
         caps = DesiredCapabilities.CHROME.copy()
         caps["goog:loggingPrefs"] = {"performance": "ALL"}
@@ -45,13 +47,15 @@ class WebDriverUtil:
         return driver
         
         
-    def getDriver(self, logger):
+    def getDriver(self, logger, headless=False):
         webnuke_config_proxy_port = 33333
         webnuke_config_web_api_port = 44444
         webnuke_config_web_api_url = 'http://localhost:'+str(webnuke_config_web_api_port)
         
         chrome_options = webdriver.ChromeOptions()
         chrome_options.add_argument("--ignore-certificate-errors")
+        if headless:
+            chrome_options.add_argument("--headless")
 
         caps = DesiredCapabilities.CHROME.copy()
         caps["goog:loggingPrefs"] = {"performance": "ALL"}

--- a/quickdetect_cli.py
+++ b/quickdetect_cli.py
@@ -61,6 +61,7 @@ def main():
     parser.add_argument("url", help="URL to scan")
     parser.add_argument("-l", "--log", dest="log_path", help="Path to log file")
     parser.add_argument("-s", "--screenshot", dest="screenshot_path", help="Path to save page screenshot")
+    parser.add_argument("--headless", action="store_true", help="Run Chrome in headless mode")
     args = parser.parse_args()
 
     logger = FileLogger()
@@ -68,7 +69,7 @@ def main():
         logger.log_path = args.log_path
 
     driver_util = WebDriverUtil()
-    driver = driver_util.getDriver(logger)
+    driver = driver_util.getDriver(logger, headless=args.headless)
     try:
         driver.get(args.url)
         screen = DummyScreen()


### PR DESCRIPTION
## Summary
- add a `headless` parameter to WebDriverUtil helpers
- allow mainframe, console and CLI to enable headless Chrome
- document new headless usage

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855ee30d158832ebc337e9506eced78