### PR TITLE
Remove wildcard imports

### DIFF
--- a/console.py
+++ b/console.py
@@ -3,8 +3,8 @@
 
 import argparse
 import traceback
-from libs.utils.logger import *
-from libs.mainmenu.mainframe import *
+from libs.utils.logger import FileLogger
+from libs.mainmenu.mainframe import mainframe
 
 def main():
         parser = argparse.ArgumentParser(description="Run Webnuke console")

--- a/libs/angular/angularCommands.py
+++ b/libs/angular/angularCommands.py
@@ -1,5 +1,5 @@
 from selenium.common.exceptions import WebDriverException
-from libs.angular.angularCustomJavascript import *
+
 import selenium.webdriver.support.ui as ui
 import time
 from libs.utils.logger import FileLogger

--- a/libs/angular/angularmenu.py
+++ b/libs/angular/angularmenu.py
@@ -1,5 +1,5 @@
 import curses
-from libs.angular.angularCommands import *
+from libs.angular.angularCommands import AngularCommands
 from libs.utils import MenuHelper
 from libs.utils.logger import FileLogger
 

--- a/libs/aws/awsmenu.py
+++ b/libs/aws/awsmenu.py
@@ -1,7 +1,7 @@
 import curses
 from selenium.common.exceptions import WebDriverException
 
-from libs.aws.awscommands import *
+from libs.aws.awscommands import AWSCommands
 from libs.utils import MenuHelper
 
 class AWSScreen:

--- a/libs/brutelogin/bruteloginmenu.py
+++ b/libs/brutelogin/bruteloginmenu.py
@@ -1,7 +1,7 @@
 import curses
 from selenium.common.exceptions import WebDriverException
 
-from libs.brutelogin.brutelogincommands import *
+from libs.brutelogin.brutelogincommands import BruteLoginCommands
 from libs.utils import MenuHelper
 
 class BruteLoginScreen:

--- a/libs/followme/followmecommands.py
+++ b/libs/followme/followmecommands.py
@@ -1,6 +1,6 @@
 import time
 import _thread
-from libs.utils.WebDriverUtil import *
+from libs.utils.WebDriverUtil import WebDriverUtil
 from libs.utils.logger import FileLogger
 
 class FollowmeCommands:

--- a/libs/followme/followmemenu.py
+++ b/libs/followme/followmemenu.py
@@ -1,5 +1,5 @@
 import time
-from libs.followme.followmecommands import *
+from libs.followme.followmecommands import FollowmeCommands
 from libs.utils import MenuHelper
 
 class FollowmeScreen:

--- a/libs/htmltools/htmlmenu.py
+++ b/libs/htmltools/htmlmenu.py
@@ -1,7 +1,6 @@
 import curses
 from selenium.common.exceptions import WebDriverException
-from libs.htmltools.htmlcommands import *
-from libs.htmltools.htmltoolsscript import *
+from libs.htmltools.htmlcommands import HTMLCommands
 from libs.utils import MenuHelper
 
 class HTMLScreen:

--- a/libs/javascript/javascriptmenu.py
+++ b/libs/javascript/javascriptmenu.py
@@ -1,11 +1,10 @@
 import curses
 from selenium.common.exceptions import WebDriverException
 
-from libs.javascript.javascriptscript import *
 from libs.utils import MenuHelper
 from libs.utils.logger import FileLogger
-from libs.javascript.javascriptcommands import *
-from libs.javascript.jswalker import *
+from libs.javascript.javascriptcommands import JavascriptCommands
+from libs.javascript.jswalker import JSWalker
 from libs.javascript.jsshell import JSShell
 
 

--- a/libs/jsconsole/JSConsole.py
+++ b/libs/jsconsole/JSConsole.py
@@ -1,5 +1,4 @@
 from selenium.common.exceptions import WebDriverException
-from libs.jsconsole.jsconsolescript import *
 from libs.utils.logger import FileLogger
         
 

--- a/libs/mainmenu/mainframe.py
+++ b/libs/mainmenu/mainframe.py
@@ -1,22 +1,25 @@
 import curses
 import time
 import atexit
-from libs.utils.WebDriverUtil import *
-from libs.utils.cursesutil import *
-from libs.javascript.javascriptmenu import *
-from libs.angular.angularmenu import *
-from libs.htmltools.htmlmenu import *
-from libs.quickdetect.QuickDetect import *
-from libs.jsconsole.JSConsole import *
-from libs.spider.spiderscreen import *
-from libs.spider.spidercommands import *
-from libs.utils.javascriptinjector import *
-from libs.mainmenu.mainmenuscreen import *
-from libs.followme.followmemenu import *
-from libs.brutelogin.bruteloginmenu import *
-from libs.aws.awsmenu import *
-from libs.xss.xssmenu import *
-from libs.cms.cmsmenu import *
+from libs.utils.WebDriverUtil import WebDriverUtil
+from libs.utils.cursesutil import CursesUtil
+from libs.javascript.javascriptmenu import JavascriptScreen
+from libs.angular.angularmenu import AngularScreen
+from libs.htmltools.htmlmenu import HTMLScreen
+from libs.quickdetect.QuickDetect import QuickDetect
+from libs.jsconsole.JSConsole import JSConsole
+from libs.spider.spiderscreen import SpiderScreen
+from libs.utils.javascriptinjector import JavascriptInjector
+from libs.mainmenu.mainmenuscreen import MainMenuScreen
+from libs.followme.followmemenu import FollowmeScreen
+from libs.brutelogin.bruteloginmenu import BruteLoginScreen
+from libs.aws.awsmenu import AWSScreen
+from libs.xss.xssmenu import XSSScreen
+from libs.cms.cmsmenu import CMSScreen
+from libs.jsconsole.jsconsolescript import JSConsoleScript
+from libs.javascript.javascriptscript import JavascriptScript
+from libs.htmltools.htmltoolsscript import HTMLToolsScript
+from libs.angular.angularCustomJavascript import AngularCustomJavascript
 import subprocess
 import os
 import sys

--- a/libs/quickdetect/QuickDetect.py
+++ b/libs/quickdetect/QuickDetect.py
@@ -1,10 +1,10 @@
 import curses
-from libs.quickdetect.AngularUtil import *
-from libs.quickdetect.WordPressUtil import *
-from libs.quickdetect.DrupalUtil import *
+from libs.quickdetect.AngularUtil import AngularUtilV2
+from libs.quickdetect.WordPressUtil import WordPressUtil
+from libs.quickdetect.DrupalUtil import DrupalUtil
 from libs.quickdetect.SitecoreUtil import SitecoreUtil
-from libs.quickdetect.JQueryUtil import *
-from libs.quickdetect.AWSS3Util import *
+from libs.quickdetect.JQueryUtil import JQueryUtil
+from libs.quickdetect.AWSS3Util import AWSS3Util
 from libs.quickdetect.CloudIPUtil import CloudIPUtil
 from libs.quickdetect.O365Util import O365Util
 from libs.quickdetect.MXEmailUtil import MXEmailUtil

--- a/libs/spider/spiderscreen.py
+++ b/libs/spider/spiderscreen.py
@@ -1,5 +1,5 @@
 import curses
-from libs.spider.spidercommands import *
+from libs.spider.spidercommands import SpiderCommands
 from libs.utils import MenuHelper
 from libs.utils.logger import FileLogger
 

--- a/libs/xss/xssmenu.py
+++ b/libs/xss/xssmenu.py
@@ -2,7 +2,7 @@ import curses
 from selenium.common.exceptions import WebDriverException
 from libs.utils import MenuHelper
 
-from libs.xss.xsscommands import *
+from libs.xss.xsscommands import XSSCommands
 
 class XSSScreen:
     def __init__(self, screen, webdriver, curses_util, logger):


### PR DESCRIPTION
## Summary
- replace wildcard imports with explicit names
- clean up unused imports
- ensure explicit class imports are used throughout

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6855f59f5e10832ea0eb6038cab4295f