### PR TITLE
Add helper for S3 URL discovery

### DIFF
--- a/libs/aws/awscommands.py
+++ b/libs/aws/awscommands.py
@@ -1,6 +1,7 @@
 from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.common.by import By
 from libs.utils.logger import FileLogger
+from .s3_helper import find_s3_urls
 
 class AWSCommands:
     def __init__(self, webdriver, logger=None):
@@ -11,13 +12,10 @@ class AWSCommands:
         
     def show_bucket_report(self):
         self.logger.log("finding buckets...")
-        self.extract_bucket_urls("//meta", "content")
-        self.extract_bucket_urls("//img", "src")
-        self.extract_bucket_urls("//link", "href")
-        self.extract_bucket_urls("//script", "src")
-        self.extract_bucket_urls("//a", "href")
-        self.logger.log('')
-        self.logger.log('')
+        for url in find_s3_urls(self.driver, self.known_s3_hosts):
+            self.logger.log(url)
+        self.logger.log("")
+        self.logger.log("")
         input("Press ENTER to return to menu.")
 
     def extract_bucket_urls(self, xpath: str, attribute: str) -> None:

--- a/libs/aws/s3_helper.py
+++ b/libs/aws/s3_helper.py
@@ -1,0 +1,21 @@
+from typing import List, Iterable
+from selenium.webdriver.common.by import By
+
+
+def find_s3_urls(driver, known_hosts: Iterable[str] | None = None) -> List[str]:
+    """Return a list of S3 bucket URLs discovered in the current page."""
+    hosts = list(known_hosts) if known_hosts is not None else ['.amazonaws.com']
+    urls: List[str] = []
+    searches = [
+        ("//meta", "content"),
+        ("//img", "src"),
+        ("//link", "href"),
+        ("//script", "src"),
+        ("//a", "href"),
+    ]
+    for xpath, attr in searches:
+        for tag in driver.find_elements(By.XPATH, xpath):
+            url = tag.get_attribute(attr)
+            if url and any(host in url for host in hosts):
+                urls.append(url)
+    return urls

--- a/libs/quickdetect/AWSS3Util.py
+++ b/libs/quickdetect/AWSS3Util.py
@@ -1,7 +1,7 @@
 from selenium import webdriver
-from selenium.webdriver.common.by import By
 import time
 from libs.utils.logger import FileLogger
+from libs.aws.s3_helper import find_s3_urls
 
 
 class AWSS3Util:
@@ -19,23 +19,8 @@ class AWSS3Util:
     
         
     def hasS3Buckets(self):
-        self.bucket_urls = []
-
-        def scan(xpath: str, attribute: str) -> None:
-            for tag in self.webdriver.find_elements(By.XPATH, xpath):
-                url = tag.get_attribute(attribute)
-                if url:
-                    for s3host in self.known_s3_hosts:
-                        if s3host in url:
-                            self.bucket_urls.append(url)
-                            break
-
         try:
-            scan("//meta", "content")
-            scan("//img", "src")
-            scan("//link", "href")
-            scan("//script", "src")
-            scan("//a", "href")
+            self.bucket_urls = find_s3_urls(self.webdriver, self.known_s3_hosts)
         except Exception:
             self.logger.error("ERRORORORORORO")
             raise

--- a/tests/test_s3helper.py
+++ b/tests/test_s3helper.py
@@ -1,5 +1,5 @@
 import unittest
-from libs.quickdetect.AWSS3Util import AWSS3Util
+from libs.aws.s3_helper import find_s3_urls
 
 class DummyElement:
     def __init__(self, attrs=None):
@@ -10,29 +10,26 @@ class DummyElement:
 class DummyDriver:
     def __init__(self, elements=None):
         self.elements = elements or {}
-        self.current_url = 'http://example.com/'
     def find_elements(self, by, value):
         return self.elements.get(value, [])
 
-class AWSS3UtilTests(unittest.TestCase):
-    def test_collects_bucket_urls(self):
+class S3HelperTests(unittest.TestCase):
+    def test_finds_bucket_urls(self):
         elements = {
             "//meta": [DummyElement({'content': 'http://bucket.amazonaws.com/file'})],
-            "//img": [DummyElement({'src': 'http://example.com/image'})]
+            "//img": [DummyElement({'src': 'http://example.com/img'})]
         }
         driver = DummyDriver(elements)
-        util = AWSS3Util(driver, driver.current_url)
-        self.assertTrue(util.hasS3Buckets())
-        self.assertEqual(util.get_bucket_urls(), ['http://bucket.amazonaws.com/file'])
+        urls = find_s3_urls(driver)
+        self.assertEqual(urls, ['http://bucket.amazonaws.com/file'])
 
-    def test_no_bucket_urls(self):
+    def test_returns_empty_when_no_buckets(self):
         elements = {
             "//meta": [DummyElement({'content': 'http://example.com/file'})]
         }
         driver = DummyDriver(elements)
-        util = AWSS3Util(driver, driver.current_url)
-        self.assertFalse(util.hasS3Buckets())
-        self.assertEqual(util.get_bucket_urls(), [])
+        urls = find_s3_urls(driver)
+        self.assertEqual(urls, [])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- add new `find_s3_urls` helper in `libs/aws/s3_helper.py`
- refactor `AWSCommands` and `AWSS3Util` to use helper
- create unit tests for helper and update existing S3 util test

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest tests/test_s3helper.py tests/test_s3util.py tests/test_aws.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6855f775db18832ebfaf1f1837692734