### PR TITLE
Refactor input pauses into helper

### DIFF
--- a/libs/angular/angularCommands.py
+++ b/libs/angular/angularCommands.py
@@ -3,6 +3,7 @@ from selenium.common.exceptions import WebDriverException
 import selenium.webdriver.support.ui as ui
 import time
 from libs.utils.logger import FileLogger
+from libs.utils import wait_for_enter
 
 class AngularCommands:
     def __init__(self, webdriver, jsinjector, logger=None):
@@ -36,7 +37,7 @@ class AngularCommands:
         self.jsinjector.execute_javascript(self.driver, javascript_function)
         self.logger.log('')
         self.logger.log('')
-        input("Press ENTER to return to menu.")
+        wait_for_enter()
         
     def show_ngResource_tests(self):
         # ngResource classes generally communicate with api endpoints... run with proxy to capture api calls.
@@ -48,7 +49,7 @@ class AngularCommands:
         self.logger.log(result)
         self.logger.log('')
         self.logger.log('')
-        input("Press ENTER to return to menu.")
+        wait_for_enter()
         
     def show_http_tests(self):
         # ngResource classes generally communicate with api endpoints... run with proxy to capture api calls.
@@ -60,5 +61,5 @@ class AngularCommands:
         self.logger.log(result)
         self.logger.log('')
         self.logger.log('')
-        input("Press ENTER to return to menu.")     
+        wait_for_enter()
         

--- a/libs/aws/awscommands.py
+++ b/libs/aws/awscommands.py
@@ -1,6 +1,7 @@
 from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.common.by import By
 from libs.utils.logger import FileLogger
+from libs.utils import wait_for_enter
 from .s3_helper import find_s3_urls
 
 class AWSCommands:
@@ -16,7 +17,7 @@ class AWSCommands:
             self.logger.log(url)
         self.logger.log("")
         self.logger.log("")
-        input("Press ENTER to return to menu.")
+        wait_for_enter()
 
     def extract_bucket_urls(self, xpath: str, attribute: str) -> None:
         """Generic helper to look for bucket URLs in matching elements."""

--- a/libs/brutelogin/brutelogincommands.py
+++ b/libs/brutelogin/brutelogincommands.py
@@ -1,6 +1,7 @@
 from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.common.by import By
 from libs.utils.logger import FileLogger
+from libs.utils import wait_for_enter
 
 class BruteLoginCommands:
     def __init__(self, webdriver, logger=None):
@@ -9,7 +10,9 @@ class BruteLoginCommands:
         self.logger = logger or FileLogger()
         
     def start_brute_force(self):
-        input("Enter nukeuser into username field amd nukepass into password field then press ENTER to continue")
+        wait_for_enter(
+            "Enter nukeuser into username field amd nukepass into password field then press ENTER to continue"
+        )
         
         username_field_id = ''
         password_field_id = ''
@@ -46,7 +49,7 @@ class BruteLoginCommands:
 
         self.logger.log('')
         self.logger.log('')
-        input("Press ENTER to return to menu.")
+        wait_for_enter()
     
     def try_logins(self, loginurl, userfield, passfield):
         users=['bert', 'jimmyj']

--- a/libs/htmltools/htmlcommands.py
+++ b/libs/htmltools/htmlcommands.py
@@ -7,6 +7,7 @@ from selenium.common.exceptions import (
 from selenium.webdriver.common.by import By
 import time
 from libs.utils.logger import FileLogger
+from libs.utils import wait_for_enter
 
 class HTMLCommands:
     def __init__(self, webdriver, jsinjector, logger=None):
@@ -19,37 +20,37 @@ class HTMLCommands:
         self.jsinjector.execute_javascript(self.driver, 'wn_showHiddenFormElements()')
         self.logger.log('')
         self.logger.log('')
-        input("Press ENTER to return to menu.")
+        wait_for_enter()
 
     def show_password_fields_as_text(self):
         self.jsinjector.execute_javascript(self.driver, 'wn_showPasswordFieldsAsText()')
         self.logger.log('')
         self.logger.log('')
-        input("Press ENTER to return to menu.")     
+        wait_for_enter()
 
     def see_all_html_elements(self):
         self.jsinjector.execute_javascript(self.driver, 'wn_showAllHTMLElements()')
         self.logger.log('')
         self.logger.log('')
-        input("Press ENTER to return to menu.")
+        wait_for_enter()
     
     def remove_hidden_from_classnames(self):
         self.jsinjector.execute_javascript(self.driver, 'wn_remove_hidden_from_classnames()')
         self.logger.log('')
         self.logger.log('')
-        input("Press ENTER to return to menu.")
+        wait_for_enter()
     def show_modals(self):
         self.jsinjector.execute_javascript(self.driver, 'wn_show_modals()')
         self.logger.log('')
         self.logger.log('')
-        input("Press ENTER to return to menu.")
+        wait_for_enter()
 
     def refresh_page(self):
         """Refresh the current browser page."""
         self.driver.refresh()
         self.logger.log("Page refreshed")
         self.logger.log('')
-        input("Press ENTER to return to menu.")
+        wait_for_enter()
 
     def _handle_navigation(self, start_url: str, do_reload: bool):
         """Return all elements on the page, reloading if needed."""
@@ -124,7 +125,7 @@ class HTMLCommands:
         for url in urls_found:
             self.logger.log("\t%s" % url)
         self.logger.log('')
-        input("Press ENTER to return to menu.")
+        wait_for_enter()
         
     def type_into_everything(self):
         all_text_elements = self.driver.find_elements(By.XPATH, '//input[@type="text"]')
@@ -144,4 +145,4 @@ class HTMLCommands:
 
 
         self.logger.log('')
-        input("Press ENTER to return to menu.")
+        wait_for_enter()

--- a/libs/javascript/javascriptcommands.py
+++ b/libs/javascript/javascriptcommands.py
@@ -1,6 +1,7 @@
 from selenium.common.exceptions import WebDriverException
 import sys
 from libs.utils.logger import FileLogger
+from libs.utils import wait_for_enter
 
 
 class JavascriptCommands:
@@ -15,7 +16,7 @@ class JavascriptCommands:
         self.jsinjector.execute_javascript(self.driver, 'wn_findStringsWithUrls();')
         self.logger.log('')
         self.logger.log('')
-        input("Press ENTER to return to menu.")
+        wait_for_enter()
 
 
     def walk_functions(self):
@@ -38,7 +39,7 @@ class JavascriptCommands:
             self.logger.log("%s [%s]" % (record['fullpath'], record['type']))
         self.logger.log('')
         self.logger.log('')
-        input("Press ENTER to return to menu.")
+        wait_for_enter()
 
 
     def search_for_document_javascript_methods(self):
@@ -53,7 +54,7 @@ var full = jsproberesults.join(','); console.log(full);
         self.jsinjector.execute_javascript(self.driver, script_to_include)
         self.logger.log('')
         self.logger.log('')
-        input("Press ENTER to return to menu.")
+        wait_for_enter()
         
     def run_lone_javascript_functions(self):
         self.logger.log("getting global window object")
@@ -101,13 +102,13 @@ var full = jsproberesults.join(','); console.log(full);
             raise
 
         self.logger.log('')
-        input("Press ENTER to return to menu.")
+        wait_for_enter()
 
     def show_cookies(self):
         self.jsinjector.execute_javascript(self.driver, 'wn_showCookie()')
         self.logger.log('')
         self.logger.log('')
-        input("Press ENTER to return to menu.")
+        wait_for_enter()
 
     def dump_browser_objects(self, filepath='libs/javascript/browser_builtins.txt'):
         try:
@@ -119,7 +120,7 @@ var full = jsproberesults.join(','); console.log(full);
             self.logger.log(f'Saved {len(objects)} objects to {filepath}')
         except WebDriverException as e:
             self.logger.error(f'Selenium Exception: Message: {str(e)}')
-        input("Press ENTER to return to menu.")
+        wait_for_enter()
 
 
 

--- a/libs/javascript/javascriptmenu.py
+++ b/libs/javascript/javascriptmenu.py
@@ -1,7 +1,7 @@
 import curses
 from selenium.common.exceptions import WebDriverException
 
-from libs.utils import MenuHelper
+from libs.utils import MenuHelper, wait_for_enter
 from libs.utils.logger import FileLogger
 from libs.javascript.javascriptcommands import JavascriptCommands
 from libs.javascript.jswalker import JSWalker
@@ -37,6 +37,6 @@ class JavascriptScreen:
     def _run_shell(self):
         if self.driver == 'notset':
             self.logger.log("Javascript Shell requires a loaded page. Use GOTO to open a URL first.")
-            input("Press ENTER to continue...")
+            wait_for_enter("Press ENTER to continue...")
         else:
             JSShell(self.driver, self.url_callback, logger=self.logger).run()

--- a/libs/javascript/jswalker.py
+++ b/libs/javascript/jswalker.py
@@ -1,6 +1,7 @@
 from selenium.common.exceptions import WebDriverException
 import sys
 from libs.utils.logger import FileLogger
+from libs.utils import wait_for_enter
 
 
 class JSWalker:
@@ -16,7 +17,7 @@ class JSWalker:
         self.walk_tree('this','this')
         self.logger.log('')
         self.logger.log('')
-        input("Press ENTER to return to menu.")
+        wait_for_enter()
 
 
     def walk_tree(self, rootnode, fullpath):
@@ -85,7 +86,7 @@ class JSWalker:
             raise
 
         self.logger.log('')
-        input("Press ENTER to return to menu.")
+        wait_for_enter()
 
 
             

--- a/libs/mainmenu/mainframe.py
+++ b/libs/mainmenu/mainframe.py
@@ -10,6 +10,7 @@ from libs.quickdetect.QuickDetect import QuickDetect
 from libs.jsconsole.JSConsole import JSConsole
 from libs.spider.spiderscreen import SpiderScreen
 from libs.utils.javascriptinjector import JavascriptInjector
+from libs.utils import wait_for_enter
 from libs.mainmenu.mainmenuscreen import MainMenuScreen
 from libs.followme.followmemenu import FollowmeScreen
 from libs.brutelogin.bruteloginmenu import BruteLoginScreen
@@ -296,9 +297,9 @@ class mainframe:
         result = subprocess.run(['git', 'pull'], capture_output=True, text=True)
         self.logger.log(result.stdout)
         if 'Already up to date.' in result.stdout:
-            input('No updates found. Press Enter to continue...')
+            wait_for_enter('No updates found. Press Enter to continue...')
         else:
-            input('Updates applied. Press Enter to restart...')
+            wait_for_enter('Updates applied. Press Enter to restart...')
             os.execv(sys.executable, [sys.executable] + sys.argv)
 
     def _load_history(self):

--- a/libs/spider/spidercommands.py
+++ b/libs/spider/spidercommands.py
@@ -1,6 +1,7 @@
 import time
 from selenium.webdriver.common.by import By
 from libs.utils.logger import FileLogger
+from libs.utils import wait_for_enter
 
 class SpiderCommands:
     def __init__(self, webdriver, logger=None):
@@ -27,7 +28,7 @@ class SpiderCommands:
             
         self.logger.log('')
         self.logger.log('')
-        input("Finished, Press ENTER to return to menu.")
+        wait_for_enter("Finished, Press ENTER to return to menu.")
         
     def build_full_url(self, url, line):
         url_to_return = url

--- a/libs/utils/__init__.py
+++ b/libs/utils/__init__.py
@@ -1,2 +1,18 @@
 from .menuhelper import MenuHelper
 from .networklogger import NetworkLogger
+
+
+def wait_for_enter(prompt: str = "Press ENTER to return to menu.") -> None:
+    """Pause execution until the user presses ENTER.
+
+    This helper centralizes all the little pauses sprinkled throughout
+    the command modules.  It simply calls ``input`` with the provided
+    prompt and ignores ``EOFError`` so tests can mock ``input`` without
+    blowing up.
+    """
+    try:
+        input(prompt)
+    except EOFError:
+        # When stdin is closed or in automated tests, just continue.
+        pass
+

--- a/libs/utils/cursesutil.py
+++ b/libs/utils/cursesutil.py
@@ -2,6 +2,7 @@ import curses
 
 from os import system
 from libs.utils.logger import FileLogger
+from libs.utils import wait_for_enter
 
 class CursesUtil:
     def __init__(self, logger=None):
@@ -64,5 +65,5 @@ class CursesUtil:
             self.logger.log("Command executed correctly")
         else:
             self.logger.error("Command terminated with error")
-        input("Press enter")
+        wait_for_enter("Press enter")
         self.logger.log("")

--- a/libs/xss/xsscommands.py
+++ b/libs/xss/xsscommands.py
@@ -2,6 +2,7 @@ from selenium.common.exceptions import UnexpectedAlertPresentException
 from selenium.webdriver.common.by import By
 import time
 from libs.utils.logger import FileLogger
+from libs.utils import wait_for_enter
 
 class XSSCommands:
     def __init__(self, webdriver, logger=None):
@@ -28,7 +29,7 @@ class XSSCommands:
                 self.logger.error(f'Error during XSS check: {e}')
         self.logger.log('')
         self.logger.log('')
-        input("Press ENTER to return to menu.")
+        wait_for_enter()
 
     def create_window_name_exploit(self, payload=None, filename="windowname.html"):
         if payload is None:
@@ -41,7 +42,7 @@ class XSSCommands:
             self.logger.log(f"Exploit file written to {filename}")
         except Exception as exc:
             self.logger.error(f"Failed to write exploit file: {exc}")
-        input("Press ENTER to return to menu.")
+        wait_for_enter()
 
     def test_post_message(self, message=None):
         if message is None:
@@ -52,7 +53,7 @@ class XSSCommands:
             self.logger.log("postMessage sent")
         except Exception as exc:
             self.logger.error(f"Failed to send postMessage: {exc}")
-        input("Press ENTER to return to menu.")
+        wait_for_enter()
         
 
 


### PR DESCRIPTION
## Summary
- add `wait_for_enter` utility
- use helper for pause prompts across command modules

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'selenium')*

------
https://chatgpt.com/codex/tasks/task_e_6855fdd4c06c832eb5ecb6b1729b3bdc