### PR TITLE
Add multi-URL and HAR support in CLI

### DIFF
--- a/quickdetect_cli.py
+++ b/quickdetect_cli.py
@@ -60,7 +60,13 @@ class DummyCursesUtil:
 
 def main():
     parser = argparse.ArgumentParser(description="Run QuickDetect on a URL")
-    parser.add_argument("url", help="URL to scan")
+    parser.add_argument("url", nargs="?", help="URL to scan")
+    parser.add_argument(
+        "-f",
+        "--url-file",
+        dest="url_file",
+        help="Path to file containing URLs to scan, one per line",
+    )
     parser.add_argument("-l", "--log", dest="log_path", help="Path to log file")
     parser.add_argument("-s", "--screenshot", dest="screenshot_path", help="Path to save page screenshot")
     parser.add_argument("--headless", action="store_true", help="Run Chrome in headless mode")
@@ -71,35 +77,75 @@ def main():
         dest="json_path",
         help="Output results as JSON. Optionally specify a file path; defaults to stdout",
     )
+    parser.add_argument(
+        "--har",
+        nargs="?",
+        const="-",
+        dest="har_path",
+        help="Output HAR network data. Optionally specify a file path; defaults to stdout",
+    )
     args = parser.parse_args()
 
     logger = FileLogger()
     if args.log_path:
         logger.log_path = args.log_path
 
+    urls = []
+    if args.url:
+        urls.append(args.url)
+    if args.url_file:
+        try:
+            with open(args.url_file, "r", encoding="utf-8") as f:
+                urls.extend([u.strip() for u in f if u.strip()])
+        except OSError as exc:
+            parser.error(f"Error reading URL file: {exc}")
+
+    if not urls:
+        parser.error("A URL or --url-file is required")
+
     driver_util = WebDriverUtil()
     driver = driver_util.getDriver(logger, headless=args.headless)
+    results = []
+    har_results = []
     try:
-        driver.get(args.url)
-        screen = DummyScreen()
-        curses_util = DummyCursesUtil(logger, screen)
-        qd = QuickDetect(screen, driver, curses_util, logger)
-        qd.run(screenshot_path=args.screenshot_path)
-        findings = [
-            line.strip()
-            for line in screen.lines
-            if line.strip() and "PRESS M" not in line and "WEBNUKE" not in line
-        ]
+        for target in urls:
+            driver.get(target)
+            screen = DummyScreen()
+            curses_util = DummyCursesUtil(logger, screen)
+            qd = QuickDetect(screen, driver, curses_util, logger)
+            qd.run(screenshot_path=args.screenshot_path)
+            findings = [
+                line.strip()
+                for line in screen.lines
+                if line.strip() and "PRESS M" not in line and "WEBNUKE" not in line
+            ]
+            results.append({"url": target, "findings": findings})
+            if args.har_path is not None:
+                har_results.append({"url": target, "har": qd.get_network_har()})
+
         if args.json_path is not None:
-            data = json.dumps({"findings": findings}, indent=2)
+            if len(results) == 1 and args.har_path is None:
+                data = json.dumps({"findings": results[0]["findings"]}, indent=2)
+            else:
+                data = json.dumps({"results": results}, indent=2)
             if args.json_path == "-":
                 print(data)
             else:
                 with open(args.json_path, "w", encoding="utf-8") as f:
                     f.write(data + "\n")
         else:
-            for line in findings:
-                print(line)
+            for rec in results:
+                for line in rec["findings"]:
+                    print(line)
+
+        if args.har_path is not None:
+            har_output = har_results[0]["har"] if len(har_results) == 1 else har_results
+            if args.har_path == "-":
+                print(json.dumps(har_output, indent=2))
+            else:
+                with open(args.har_path, "w", encoding="utf-8") as f:
+                    json.dump(har_output, f, indent=2)
+                    f.write("\n")
     finally:
         driver_util.quit_driver(driver)
 

--- a/tests/test_quickdetect_cli.py
+++ b/tests/test_quickdetect_cli.py
@@ -77,6 +77,83 @@ class QuickDetectCLITests(unittest.TestCase):
             import os
             os.remove(out_path)
 
+    def test_url_file_and_json(self):
+        dummy_lines = ['Tech Detected']
+        with tempfile.NamedTemporaryFile(mode='w+', delete=False) as tf:
+            tf.write('http://one.com\nhttp://two.com\n')
+            url_file = tf.name
+        try:
+            class DummyQD:
+                def __init__(self, screen, driver, curses_util, logger):
+                    self.screen = screen
+                def run(self, screenshot_path=None):
+                    self.screen.lines.extend(dummy_lines)
+                def get_network_har(self, path=None):
+                    return []
+
+            class DummyLogger:
+                def log(self, *_):
+                    pass
+                debug = log
+                error = log
+
+            class DummyDriver:
+                def get(self, url):
+                    pass
+
+            with patch('quickdetect_cli.FileLogger', return_value=DummyLogger()), \
+                 patch('quickdetect_cli.WebDriverUtil.getDriver', return_value=DummyDriver()), \
+                 patch('quickdetect_cli.WebDriverUtil.quit_driver'), \
+                 patch('quickdetect_cli.QuickDetect', DummyQD):
+                buf = io.StringIO()
+                with patch('sys.stdout', new=buf):
+                    self._run_cli(['quickdetect_cli.py', '--url-file', url_file, '--json'])
+                data = json.loads(buf.getvalue())
+                self.assertIn('results', data)
+                self.assertEqual(len(data['results']), 2)
+                for entry in data['results']:
+                    self.assertEqual(entry['findings'], dummy_lines)
+        finally:
+            import os
+            os.remove(url_file)
+
+    def test_har_output(self):
+        dummy_lines = ['Info']
+        dummy_har = [{'url': 'http://example.com', 'status': 200}]
+
+        class DummyQD:
+            def __init__(self, screen, driver, curses_util, logger):
+                self.screen = screen
+            def run(self, screenshot_path=None):
+                self.screen.lines.extend(dummy_lines)
+            def get_network_har(self, path=None):
+                return dummy_har
+
+        class DummyLogger:
+            def log(self, *_):
+                pass
+            debug = log
+            error = log
+
+        class DummyDriver:
+            def get(self, url):
+                pass
+
+        with tempfile.NamedTemporaryFile(mode='r+', delete=False) as tf:
+            har_path = tf.name
+        try:
+            with patch('quickdetect_cli.FileLogger', return_value=DummyLogger()), \
+                 patch('quickdetect_cli.WebDriverUtil.getDriver', return_value=DummyDriver()), \
+                 patch('quickdetect_cli.WebDriverUtil.quit_driver'), \
+                 patch('quickdetect_cli.QuickDetect', DummyQD):
+                self._run_cli(['quickdetect_cli.py', 'http://example.com', '--har', har_path])
+            with open(har_path) as f:
+                data = json.load(f)
+            self.assertEqual(data, dummy_har)
+        finally:
+            import os
+            os.remove(har_path)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- add `--url-file` and `--har` options to `quickdetect_cli`
- iterate over URLs and aggregate results
- extend tests for new options

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856012d7a80832ea096dbea5f34b366