### PR TITLE
Clear log on startup

### DIFF
--- a/console.py
+++ b/console.py
@@ -13,6 +13,8 @@ def main():
         args = parser.parse_args()
 
         log_file = FileLogger()
+        if hasattr(log_file, 'clear'):
+                log_file.clear()
         log_file.debug('Webnuke started.')
 
         try:

--- a/libs/utils/logger.py
+++ b/libs/utils/logger.py
@@ -8,6 +8,10 @@ class FileLogger:
         # Default to logging in the current working directory
         self.log_path = os.path.join(os.getcwd(), 'webnuke.log')
 
+    def clear(self) -> None:
+        """Remove any existing log contents."""
+        open(self.log_path, 'w', encoding='utf-8').close()
+
     def _write(self, text: str) -> None:
         with open(self.log_path, 'a', encoding='utf-8') as logfile:
             logfile.write(f'{text}\n')

--- a/quickdetect_cli.py
+++ b/quickdetect_cli.py
@@ -89,6 +89,8 @@ def main():
     logger = FileLogger()
     if args.log_path:
         logger.log_path = args.log_path
+    if hasattr(logger, 'clear'):
+        logger.clear()
 
     urls = []
     if args.url:


### PR DESCRIPTION
## Summary
- add a clear() helper to the logger
- wipe the log at console launch
- clear the log in QuickDetect CLI

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856092fcfb4832e94d5536b2fa8863c