### PR TITLE
Fix isAngularApp return logic

### DIFF
--- a/libs/quickdetect/AngularUtil.py
+++ b/libs/quickdetect/AngularUtil.py
@@ -121,13 +121,14 @@ class AngularUtil:
         return result.get_attribute("ng-app")
         
     def isAngularApp(self, webdriver):
-        result = []
         try:
-            result = webdriver.execute_script('return self.angular')
-            return len(result) > 0
+            result = webdriver.execute_script("return self.angular")
+            if result is None:
+                return False
+            return bool(result)
         except Exception as e:
             self.logger.error(f'Error checking Angular app: {e}')
-        
+
         return False
         
     def getApplicationParts(self, webdriver):


### PR DESCRIPTION
## Summary
- guard against `None` return from `execute_script` in `AngularUtil.isAngularApp`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68560e4d5290832e885f3fce8b595632