### PR TITLE
Fix proxy_port attr type

### DIFF
--- a/libs/mainmenu/mainframe.py
+++ b/libs/mainmenu/mainframe.py
@@ -276,7 +276,7 @@ class mainframe:
     def create_browser_instance(self):
         self.webdriver_util = WebDriverUtil()
         self.webdriver_util.setDebug(self.debug)
-        port = int(self.proxy_port) if self.proxy_port.isdigit() else 0
+        port = int(self.proxy_port) if str(self.proxy_port).isdigit() else 0
         if self.proxy_host and port:
             self.logger.log("getting webdriver with proxy support")
             return self.webdriver_util.getDriverWithProxySupport(


### PR DESCRIPTION
## Summary
- handle non-string proxy port values in mainframe

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856169d93fc832ea26e491a5ca201e2