### PR TITLE
Add HAR capture support to console

### DIFF
--- a/console.py
+++ b/console.py
@@ -10,6 +10,20 @@ def main():
         parser = argparse.ArgumentParser(description="Run Webnuke console")
         parser.add_argument("url", nargs="?", help="URL to open on startup")
         parser.add_argument("--headless", action="store_true", help="Run Chrome in headless mode")
+        parser.add_argument(
+            "--har",
+            nargs="?",
+            const="webnuke.har.json",
+            dest="har_path",
+            help="Save HAR network data after QuickDetect. Optionally specify a file path; defaults to webnuke.har.json",
+        )
+        parser.add_argument("--proxy-host", dest="proxy_host", help="Proxy server hostname or IP")
+        parser.add_argument(
+            "--proxy-port",
+            dest="proxy_port",
+            type=int,
+            help="Proxy server port number",
+        )
         args = parser.parse_args()
 
         log_file = FileLogger()
@@ -18,7 +32,13 @@ def main():
         log_file.debug('Webnuke started.')
 
         try:
-                mf = mainframe(log_file, headless=args.headless)
+                mf = mainframe(
+                    log_file,
+                    headless=args.headless,
+                    har_path=args.har_path,
+                    proxy_host=args.proxy_host,
+                    proxy_port=args.proxy_port,
+                )
                 if args.url:
                         mf.open_url(args.url)
                 mf.show_main_screen()

--- a/libs/mainmenu/mainframe.py
+++ b/libs/mainmenu/mainframe.py
@@ -27,11 +27,12 @@ import os
 import sys
 
 class mainframe:
-    def __init__(self, logger, headless=False):
+    def __init__(self, logger, headless=False, har_path=None, proxy_host='', proxy_port=0):
         self.debug = True
         self.headless = headless
-        self.proxy_host = ''
-        self.proxy_port = 0
+        self.har_path = har_path
+        self.proxy_host = proxy_host
+        self.proxy_port = proxy_port
         self.driver = 'notset'
         self.current_url = "NONE"
         self.warning = ''
@@ -97,7 +98,14 @@ class mainframe:
                     "QUICKDETECT requires a url is loaded, please set a url using GOTO"
                 )
                 return
-            QuickDetect(self.screen, self.driver, self.curses_util, self.logger).run()
+            qd = QuickDetect(self.screen, self.driver, self.curses_util, self.logger)
+            qd.run()
+            if self.har_path:
+                path = self.har_path
+                if os.path.isdir(self.har_path):
+                    ts = time.strftime("%Y%m%d_%H%M%S")
+                    path = os.path.join(self.har_path, f"har_{ts}.json")
+                qd.get_network_har(path)
 
         def jsconsole_cmd(args):
             self.curses_util.close_screen()


### PR DESCRIPTION
## Summary
- allow webnuke console to save network HAR data
- update QuickDetect flow to write HAR files when specified
- add CLI options for proxy host and port

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68562523cd64832eafe95a595c81b936