### PR TITLE
Fix CI by installing pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,5 +14,6 @@ jobs:
         with:
           python-version: '3.x'
       - run: pip install .
+      - run: pip install pytest
       - run: python -m py_compile $(git ls-files '*.py')
       - run: python -m pytest -q


### PR DESCRIPTION
## Summary
- fix failing GitHub action by installing pytest before running tests

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685638049c78832e930201ba0c829875