### PR TITLE
Add HAR log message on exit

### DIFF
--- a/libs/mainmenu/mainframe.py
+++ b/libs/mainmenu/mainframe.py
@@ -362,6 +362,7 @@ class mainframe:
                 path = os.path.join(self.har_path, f"har_{ts}.json")
                 with open(path, "w", encoding="utf-8") as f:
                     json.dump(self.network_logger.get_har(), f, indent=2)
+                self.logger.log(f"Saved network HAR to {path}")
             except Exception as exc:
                 self.logger.error(f"Error writing HAR file: {exc}")
             finally:

--- a/tests/test_mainframe.py
+++ b/tests/test_mainframe.py
@@ -9,6 +9,18 @@ class DummyLogger:
     def log(self, text):
         pass
 
+class RecordLogger:
+    def __init__(self):
+        self.records = []
+
+    def log(self, text):
+        self.records.append(text)
+
+    def error(self, text):
+        self.records.append(text)
+
+    debug = log
+
 class DummyDriver:
     def __init__(self):
         self.current_url = ''
@@ -79,6 +91,17 @@ class MainframeHistoryTests(unittest.TestCase):
         with open(os.path.join('har_out', files[0]), 'r', encoding='utf-8') as f:
             data = json.load(f)
         self.assertEqual(data, [{"url": "http://example.com", "status": 200}])
+        os.remove(os.path.join('har_out', files[0]))
+        os.rmdir('har_out')
+
+    def test_har_path_logged(self):
+        logger = RecordLogger()
+        self.mf.logger = logger
+        self.mf.har_path = 'har_out'
+        self.mf.open_url('http://example.com')
+        self.mf._save_network_har()
+        self.assertTrue(any('har_out' in rec and 'har_' in rec for rec in logger.records))
+        files = os.listdir('har_out')
         os.remove(os.path.join('har_out', files[0]))
         os.rmdir('har_out')
 


### PR DESCRIPTION
## Summary
- log HAR file path after saving network logs
- check that HAR file path is written to the logger

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856394b7724832e99906d5818fe05e1