### PR TITLE
Enable HAR logs by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ The console also supports running Chrome in headless mode with the `--headless` 
 ```
 python console.py --headless https://example.com
 ```
+Network traffic is logged automatically when the console exits. HAR files are
+saved into the `har_logs` directory by default; use `--har <dir>` to change the
+output location.
 
 ### QuickDetect CLI
 

--- a/console.py
+++ b/console.py
@@ -14,6 +14,7 @@ def main():
             "--har",
             nargs="?",
             const="har_logs",
+            default="har_logs",
             dest="har_path",
             help=(
                 "Folder to save HAR network data when exiting the console. "


### PR DESCRIPTION
## Summary
- capture HAR data by default
- document default HAR location in README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68563bf0ccd4832e941e3712befee61f