### PR TITLE
Add CORS wildcard detection

### DIFF
--- a/libs/quickdetect/CORSUtil.py
+++ b/libs/quickdetect/CORSUtil.py
@@ -1,0 +1,34 @@
+from libs.utils.logger import FileLogger
+
+class CORSUtil:
+    """Utility to inspect CORS related headers."""
+
+    def __init__(self, webdriver, logger=None):
+        self.webdriver = webdriver
+        self.logger = logger or FileLogger()
+
+    def _get_headers(self):
+        try:
+            headers = getattr(self.webdriver, "last_response_headers", None)
+            if headers is None:
+                headers = getattr(self.webdriver, "response_headers", None)
+            if isinstance(headers, dict):
+                return {k.lower(): v for k, v in headers.items()}
+        except Exception as e:
+            self.logger.error(f"Error retrieving response headers: {e}")
+        return {}
+
+    def get_allow_origin(self):
+        """Return the value of the Access-Control-Allow-Origin header."""
+        return self._get_headers().get("access-control-allow-origin")
+
+    def allows_wildcard(self) -> bool:
+        """Return True if ACAO header allows any origin."""
+        value = self.get_allow_origin()
+        if not value:
+            return False
+        try:
+            return "*" in str(value)
+        except Exception as e:
+            self.logger.error(f"Error checking CORS header: {e}")
+            return False

--- a/libs/quickdetect/QuickDetect.py
+++ b/libs/quickdetect/QuickDetect.py
@@ -23,6 +23,7 @@ from libs.quickdetect.CSPUtil import CSPUtil
 from libs.quickdetect.ManifestUtil import ManifestUtil
 from libs.quickdetect.WebSocketUtil import WebSocketUtil
 from libs.quickdetect.SecurityHeadersUtil import SecurityHeadersUtil
+from libs.quickdetect.CORSUtil import CORSUtil
 from libs.utils import NetworkLogger
 
 class QuickDetect:
@@ -143,6 +144,10 @@ class QuickDetect:
         has_xfo = security_util.has_x_frame_options()
         has_xcto = security_util.has_x_content_type_options()
 
+        cors_util = CORSUtil(self.driver, self.logger)
+        cors_wildcard = cors_util.allows_wildcard()
+        cors_origin = cors_util.get_allow_origin() if cors_wildcard else None
+
         service_worker_info = None
         if sw_supported:
             if sw_registered:
@@ -189,6 +194,7 @@ class QuickDetect:
             (has_hsts, "HSTS Enabled", None),
             (has_xfo, "X-Frame-Options Set", None),
             (has_xcto, "X-Content-Type-Options Set", None),
+            (cors_wildcard, "CORS Allows Any Origin", cors_origin),
             (has_manifest, "Web App Manifest Detected", manifest_url),
             (has_websocket, "WebSocket Detected", None),
         ]

--- a/libs/quickdetect/__init__.py
+++ b/libs/quickdetect/__init__.py
@@ -9,3 +9,4 @@ from .CSPUtil import CSPUtil
 from .ManifestUtil import ManifestUtil
 from .WebSocketUtil import WebSocketUtil
 from .SecurityHeadersUtil import SecurityHeadersUtil
+from .CORSUtil import CORSUtil

--- a/tests/test_quickdetect.py
+++ b/tests/test_quickdetect.py
@@ -13,6 +13,7 @@ from libs.quickdetect.NextJSUtil import NextJSUtil
 from libs.quickdetect.GraphQLUtil import GraphQLUtil
 from libs.quickdetect.ManifestUtil import ManifestUtil
 from libs.quickdetect.WebSocketUtil import WebSocketUtil
+from libs.quickdetect.CORSUtil import CORSUtil
 from selenium.webdriver.common.by import By
 
 class DummyElement:
@@ -335,6 +336,26 @@ class WebSocketUtilTests(unittest.TestCase):
         self.assertFalse(util.has_websocket())
 
 
+class CORSUtilTests(unittest.TestCase):
+    def test_allows_wildcard_true(self):
+        class Driver:
+            def __init__(self):
+                self.last_response_headers = {"Access-Control-Allow-Origin": "*"}
+
+        driver = Driver()
+        util = CORSUtil(driver)
+        self.assertTrue(util.allows_wildcard())
+
+    def test_allows_wildcard_false(self):
+        class Driver:
+            def __init__(self):
+                self.last_response_headers = {"Access-Control-Allow-Origin": "https://example.com"}
+
+        driver = Driver()
+        util = CORSUtil(driver)
+        self.assertFalse(util.allows_wildcard())
+
+
 class QuickDetectScreenshotTests(unittest.TestCase):
     def test_run_saves_screenshot_when_path_given(self):
         class DummyLogger:
@@ -411,6 +432,7 @@ class QuickDetectScreenshotTests(unittest.TestCase):
             ManifestUtil=DummyUtil,
             WebSocketUtil=DummyUtil,
             SecurityHeadersUtil=DummyUtil,
+            CORSUtil=DummyUtil,
         ):
             qd = QDModule.QuickDetect(screen, dummy, curses_util, logger)
             qd.run(screenshot_path='test.png')
@@ -498,6 +520,7 @@ class QuickDetectNetworkTests(unittest.TestCase):
             ManifestUtil=DummyUtil,
             WebSocketUtil=DummyUtil,
             SecurityHeadersUtil=DummyUtil,
+            CORSUtil=DummyUtil,
         ):
             qd = QDModule.QuickDetect(screen, dummy, curses_util, logger)
             qd.run()


### PR DESCRIPTION
## Summary
- add `CORSUtil` helper to inspect response headers for wildcards in `Access-Control-Allow-Origin`
- integrate CORS detection into `QuickDetect`
- expose `CORSUtil` via package init
- cover new logic with unit tests

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68564f6cf1dc832e94715054e3c62da4