### PR TITLE
Fix Cloudflare classification

### DIFF
--- a/libs/quickdetect/CloudIPUtil.py
+++ b/libs/quickdetect/CloudIPUtil.py
@@ -23,12 +23,12 @@ class CloudIPUtil:
                 data.get('asn_description', '')
             ).lower()
             providers = {
-                'amazon': 'AWS',
-                'google': 'Google Cloud',
-                'microsoft': 'Azure',
-                'cloudflare': 'Cloudflare',
-                'digitalocean': 'DigitalOcean',
-                'ovh': 'OVH'
+                'amazon': ('AWS', 'cloud'),
+                'google': ('Google Cloud', 'cloud'),
+                'microsoft': ('Azure', 'cloud'),
+                'cloudflare': ('Cloudflare', 'waf'),
+                'digitalocean': ('DigitalOcean', 'cloud'),
+                'ovh': ('OVH', 'cloud')
             }
             for key, val in providers.items():
                 if key in text:

--- a/libs/quickdetect/QuickDetect.py
+++ b/libs/quickdetect/QuickDetect.py
@@ -95,8 +95,13 @@ class QuickDetect:
         jquery_version = jquery_util.getVersionString() if is_jquery else None
 
         cloud_util = CloudIPUtil(self.current_url)
-        cloud_provider = cloud_util.get_provider()
-        has_cloud = cloud_provider is not None
+        provider_info = cloud_util.get_provider()
+        cloud_provider = None
+        provider_type = None
+        if provider_info:
+            cloud_provider, provider_type = provider_info
+        has_cloud = provider_info is not None and provider_type == "cloud"
+        has_waf = provider_info is not None and provider_type == "waf"
 
         dojo_util = DojoUtil(self.driver)
         is_dojo = dojo_util.is_dojo()
@@ -185,6 +190,7 @@ class QuickDetect:
             (is_jquery, "JQuery Discovered", jquery_version),
             (is_dojo, "Dojo Discovered", dojo_version),
             (has_cloud, "Cloud Provider Detected", cloud_provider),
+            (has_waf, "Web Application Firewall Detected", cloud_provider),
             (has_s3, "AWS S3 Bucket Detected", s3_info),
             (bool(email_provider), "Email Provider Detected", email_provider),
             (has_bookings, "Microsoft Bookings Detected", None),


### PR DESCRIPTION
## Summary
- detect Cloudflare as a web firewall instead of a cloud provider

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856580866a0832e91cf9acf03722cdd