### PR TITLE
Add favicon detection and MD5 option

### DIFF
--- a/libs/htmltools/htmlcommands.py
+++ b/libs/htmltools/htmlcommands.py
@@ -146,3 +146,28 @@ class HTMLCommands:
 
         self.logger.log('')
         wait_for_enter()
+
+    def favicon_info(self):
+        """Download the page favicon or display its MD5 hash."""
+        from libs.quickdetect.FaviconUtil import FaviconUtil
+
+        util = FaviconUtil(self.driver, self.logger)
+        url = util.get_favicon_url()
+        if not url:
+            self.logger.log('No favicon detected')
+            self.logger.log('')
+            wait_for_enter()
+            return
+        self.logger.log(f'Favicon URL: {url}')
+        choice = input('Download favicon? [y/N]: ').strip().lower()
+        if choice.startswith('y'):
+            filename = 'favicon.ico'
+            if util.download_favicon(filename):
+                self.logger.log(f'Favicon saved to {filename}')
+            else:
+                self.logger.log('Failed to download favicon')
+        md5 = util.get_favicon_md5()
+        if md5:
+            self.logger.log(f'Favicon MD5: {md5}')
+        self.logger.log('')
+        wait_for_enter()

--- a/libs/htmltools/htmlmenu.py
+++ b/libs/htmltools/htmlmenu.py
@@ -30,6 +30,7 @@ class HTMLScreen:
             ('6', "Removes hidden & hide from classnames", self.commands.remove_hidden_from_classnames),
             ('7', "Show all modals  (modal fade -> modal fade show)", self.commands.show_modals),
             ('8', "Refresh current page", self.commands.refresh_page),
+            ('9', "Favicon options", self.commands.favicon_info),
         ]
         MenuHelper.run(self.curses_util, "HTML Tools", items)
         return

--- a/libs/quickdetect/FaviconUtil.py
+++ b/libs/quickdetect/FaviconUtil.py
@@ -1,0 +1,55 @@
+from selenium.webdriver.remote.webdriver import WebDriver
+from selenium.webdriver.common.by import By
+from urllib.parse import urljoin
+import hashlib
+import requests
+from libs.utils.logger import FileLogger
+
+
+class FaviconUtil:
+    def __init__(self, webdriver: WebDriver, logger=None):
+        self.webdriver = webdriver
+        self.logger = logger or FileLogger()
+
+    def get_favicon_url(self):
+        """Return the absolute favicon URL if found, else None."""
+        try:
+            elements = self.webdriver.find_elements(By.XPATH, "//link[contains(@rel, 'icon')]")
+            if elements:
+                href = elements[0].get_attribute('href')
+                if href:
+                    return urljoin(self.webdriver.current_url, href)
+        except Exception as e:
+            self.logger.error(f'Error retrieving favicon URL: {e}')
+        return None
+
+    def has_favicon(self) -> bool:
+        return self.get_favicon_url() is not None
+
+    def download_favicon(self, path: str) -> bool:
+        """Download the favicon to ``path``. Return True on success."""
+        url = self.get_favicon_url()
+        if not url:
+            return False
+        try:
+            resp = requests.get(url, timeout=10)
+            resp.raise_for_status()
+            with open(path, 'wb') as f:
+                f.write(resp.content)
+            return True
+        except Exception as e:
+            self.logger.error(f'Error downloading favicon: {e}')
+        return False
+
+    def get_favicon_md5(self):
+        """Return the MD5 hash of the favicon contents, or None if not found."""
+        url = self.get_favicon_url()
+        if not url:
+            return None
+        try:
+            resp = requests.get(url, timeout=10)
+            resp.raise_for_status()
+            return hashlib.md5(resp.content).hexdigest()
+        except Exception as e:
+            self.logger.error(f'Error fetching favicon for MD5: {e}')
+        return None

--- a/libs/quickdetect/QuickDetect.py
+++ b/libs/quickdetect/QuickDetect.py
@@ -24,6 +24,7 @@ from libs.quickdetect.ManifestUtil import ManifestUtil
 from libs.quickdetect.WebSocketUtil import WebSocketUtil
 from libs.quickdetect.SecurityHeadersUtil import SecurityHeadersUtil
 from libs.quickdetect.CORSUtil import CORSUtil
+from libs.quickdetect.FaviconUtil import FaviconUtil
 from libs.utils import NetworkLogger
 
 class QuickDetect:
@@ -142,6 +143,10 @@ class QuickDetect:
         has_manifest = manifest_util.has_manifest()
         manifest_url = manifest_util.get_manifest_url() if has_manifest else None
 
+        favicon_util = FaviconUtil(self.driver, self.logger)
+        has_favicon = favicon_util.has_favicon()
+        favicon_url = favicon_util.get_favicon_url() if has_favicon else None
+
         websocket_util = WebSocketUtil(self.driver, self.logger)
         has_websocket = websocket_util.has_websocket()
 
@@ -205,6 +210,7 @@ class QuickDetect:
             (cors_wildcard, "CORS Allows Any Origin", cors_origin),
             (has_manifest, "Web App Manifest Detected", manifest_url),
             (has_websocket, "WebSocket Detected", None),
+            (has_favicon, "Favicon Detected", favicon_url),
         ]
 
         return detections

--- a/libs/quickdetect/__init__.py
+++ b/libs/quickdetect/__init__.py
@@ -10,3 +10,4 @@ from .ManifestUtil import ManifestUtil
 from .WebSocketUtil import WebSocketUtil
 from .SecurityHeadersUtil import SecurityHeadersUtil
 from .CORSUtil import CORSUtil
+from .FaviconUtil import FaviconUtil


### PR DESCRIPTION
## Summary
- detect favicons via QuickDetect
- expose favicon MD5/download from the HTML Tools menu

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856596fa5c0832e9d1d0eb736ff28ee