### PR TITLE
Improve network retry logic

### DIFF
--- a/libs/htmltools/htmlcommands.py
+++ b/libs/htmltools/htmlcommands.py
@@ -17,15 +17,20 @@ class HTMLCommands:
         self.logger = logger or FileLogger()
 
     def _load_url_with_retry(self, url: str, delay: int = 2) -> None:
-        """Load a URL retrying on network disconnect errors."""
+        """Load a URL retrying on network related errors."""
+        network_errors = [
+            'ERR_INTERNET_DISCONNECTED',
+            'ERR_NAME_NOT_RESOLVED',
+        ]
         while True:
             try:
                 self.driver.get(url)
                 break
             except WebDriverException as exc:
-                if 'ERR_INTERNET_DISCONNECTED' in str(exc):
+                message = str(exc)
+                if any(err in message for err in network_errors):
                     self.logger.error(
-                        f'Internet disconnected while loading {url}. Retrying...'
+                        f'Internet error while loading {url}. Retrying...'
                     )
                     time.sleep(delay)
                     continue

--- a/libs/xss/xsscommands.py
+++ b/libs/xss/xsscommands.py
@@ -11,14 +11,19 @@ class XSSCommands:
         self.logger = logger or FileLogger()
 
     def _load_url_with_retry(self, url, delay: int = 2) -> None:
-        """Load a URL retrying on network disconnect errors."""
+        """Load a URL retrying on network related errors."""
+        network_errors = [
+            'ERR_INTERNET_DISCONNECTED',
+            'ERR_NAME_NOT_RESOLVED',
+        ]
         while True:
             try:
                 self.driver.get(url)
                 break
             except WebDriverException as exc:
-                if 'ERR_INTERNET_DISCONNECTED' in str(exc):
-                    self.logger.error(f'Internet disconnected while loading {url}. Retrying...')
+                message = str(exc)
+                if any(err in message for err in network_errors):
+                    self.logger.error(f'Internet error while loading {url}. Retrying...')
                     time.sleep(delay)
                     continue
                 raise


### PR DESCRIPTION
## Summary
- make network errors more robust by retrying when DNS failures occur

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest tests/test_htmlcommands.py::HTMLCommandsUnitTests::test_load_url_with_retry -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68566c9b7288832ea9788ca76105d549