### PR TITLE
Add reflected parameter detection

### DIFF
--- a/libs/xss/xssmenu.py
+++ b/libs/xss/xssmenu.py
@@ -33,6 +33,7 @@ class XSSScreen:
             ('1', "Find XSS", self.commands.find_xss),
             ('2', "Create window.name exploit", lambda: self.commands.create_window_name_exploit(get_payload())),
             ('3', "Test postMessage", lambda: self.commands.test_post_message(get_message())),
+            ('4', "Find reflected parameters", self.commands.find_reflected_params),
         ]
         MenuHelper.run(self.curses_util, "XSS", items)
         return

--- a/tests/test_xss.py
+++ b/tests/test_xss.py
@@ -1,5 +1,33 @@
 import unittest
-from libs.xss.xsscommands import XSS_Url_Suggestor
+from libs.xss.xsscommands import XSS_Url_Suggestor, XSSCommands
+from unittest.mock import patch
+import urllib.parse
+
+
+class DummyElement:
+    def __init__(self, name):
+        self.name = name
+    def get_attribute(self, attr):
+        if attr == "name":
+            return self.name
+        return None
+
+
+class DummyDriver:
+    def __init__(self):
+        self.current_url = "http://example.com/page?foo=1"
+        self.page_source = ""
+        self.visited = []
+
+    def get(self, url):
+        self.visited.append(url)
+        self.current_url = url
+        parsed = urllib.parse.urlparse(url)
+        params = urllib.parse.parse_qs(parsed.query)
+        self.page_source = params.get("foo", [""])[0]
+
+    def find_elements(self, *_):
+        return [DummyElement("foo"), DummyElement("bar")]
 
 
 class XSSUrlSuggestorTests(unittest.TestCase):
@@ -18,6 +46,25 @@ class XSSUrlSuggestorTests(unittest.TestCase):
         expected_params = set(suggestor.common_param_names)
         self.assertEqual(len(urls), len(expected_params) * len(suggestor.xss_attacks))
         self.assertTrue(all(u.startswith('http://example.com/page?') for u in urls))
+
+
+class ReflectedParamTests(unittest.TestCase):
+    @patch('libs.xss.xsscommands.wait_for_enter')
+    @patch('libs.xss.xsscommands.time.sleep')
+    def test_find_reflected_params_logs(self, _sleep, _wait):
+        driver = DummyDriver()
+        class Logger:
+            def __init__(self):
+                self.records = []
+            def log(self, text):
+                self.records.append(text)
+            error = log
+            debug = log
+
+        logger = Logger()
+        cmds = XSSCommands(driver, logger)
+        cmds.find_reflected_params("TESTVAL")
+        self.assertIn("Reflected parameter found: foo", logger.records)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- support detection of reflected params without XSS payloads
- expose new option in the XSS menu
- test reflected parameter detection

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856706f6bc4832e8ac6c58458631f2e