### PR TITLE
Enhance XSS tests with HAR params

### DIFF
--- a/libs/mainmenu/mainframe.py
+++ b/libs/mainmenu/mainframe.py
@@ -175,7 +175,13 @@ class mainframe:
             ).show()
 
         def xss_cmd(args):
-            XSSScreen(self.screen, self.driver, self.curses_util, self.logger).show()
+            XSSScreen(
+                self.screen,
+                self.driver,
+                self.curses_util,
+                self.logger,
+                self.network_logger,
+            ).show()
 
         def csrf_cmd(args):
             CSRFScreen(

--- a/libs/xss/xssmenu.py
+++ b/libs/xss/xssmenu.py
@@ -5,13 +5,13 @@ from libs.utils import MenuHelper
 from libs.xss.xsscommands import XSSCommands
 
 class XSSScreen:
-    def __init__(self, screen, webdriver, curses_util, logger):
+    def __init__(self, screen, webdriver, curses_util, logger, network_logger=None):
         self.version = 2.0
         self.screen = screen
         self.driver = webdriver
         self.curses_util = curses_util
         self.logger = logger
-        self.commands = XSSCommands(self.driver, self.logger)
+        self.commands = XSSCommands(self.driver, self.logger, network_logger)
         
         
         

--- a/tests/test_xss.py
+++ b/tests/test_xss.py
@@ -47,6 +47,13 @@ class XSSUrlSuggestorTests(unittest.TestCase):
         self.assertEqual(len(urls), len(expected_params) * len(suggestor.xss_attacks))
         self.assertTrue(all(u.startswith('http://example.com/page?') for u in urls))
 
+    def test_xss_url_suggestor_har_params(self):
+        url = 'http://example.com/page'
+        har = [{'url': 'http://example.com/api?harparam=1', 'status': 200}]
+        suggestor = XSS_Url_Suggestor(url, network_har=har)
+        urls = suggestor.get_xss_urls()
+        self.assertTrue(any('harparam=' in u for u in urls))
+
 
 class ReflectedParamTests(unittest.TestCase):
     @patch('libs.xss.xsscommands.wait_for_enter')


### PR DESCRIPTION
## Summary
- incorporate captured HAR data into XSS parameter discovery
- default reflected payload changed to `heybertheyernie`
- wire XSS screen to pass network logger
- add unit test for HAR-derived parameters

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856757f7aa0832ea320c05727745180