### PR TITLE
Add summary to reflected params command

### DIFF
--- a/libs/xss/xsscommands.py
+++ b/libs/xss/xsscommands.py
@@ -101,6 +101,8 @@ class XSSCommands:
         base_url = current_url.split("?")[0]
         base_query = "&".join(f"{k}={v}" for k, v in existing.items())
 
+        found_params = []
+
         for name in param_names:
             if name in existing:
                 replaced = existing.copy()
@@ -113,10 +115,19 @@ class XSSCommands:
                 self._load_url_with_retry(test_url)
                 if test_value in self.driver.page_source:
                     self.logger.log(f"Reflected parameter found: {name}")
+                    found_params.append((name, test_url))
             except Exception as exc:
                 self.logger.error(f"Error testing {name}: {exc}")
 
         self._load_url_with_retry(current_url)
+
+        if found_params:
+            self.logger.log("Reflected parameters summary:")
+            for pname, url in found_params:
+                self.logger.log(f"  {pname}: {url}")
+        else:
+            self.logger.log("No reflected parameters detected.")
+
         wait_for_enter()
         
 

--- a/tests/test_xss.py
+++ b/tests/test_xss.py
@@ -72,6 +72,9 @@ class ReflectedParamTests(unittest.TestCase):
         cmds = XSSCommands(driver, logger)
         cmds.find_reflected_params("TESTVAL")
         self.assertIn("Reflected parameter found: foo", logger.records)
+        self.assertIn(
+            "  foo: http://example.com/page?foo=TESTVAL", logger.records
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- collect all reflected parameters and print summary including URL
- assert summary message in tests

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856786d6aa4832e900e7c5ddb3f3eec