### PR TITLE
Move quit option to end of main menu

### DIFF
--- a/libs/mainmenu/mainframe.py
+++ b/libs/mainmenu/mainframe.py
@@ -251,12 +251,12 @@ class mainframe:
             "!sh": shell_cmd,
             "17": update_cmd,
             "update": update_cmd,
-            "18": quit_cmd,
+            "18": dns_cmd,
+            "dns": dns_cmd,
+            "19": quit_cmd,
             "quit": quit_cmd,
             "q": quit_cmd,
             "d": debug_demo_cmd,
-            "19": dns_cmd,
-            "dns": dns_cmd,
         }
 
         mystr = "startup"

--- a/libs/mainmenu/mainmenuscreen.py
+++ b/libs/mainmenu/mainmenuscreen.py
@@ -22,8 +22,8 @@ class MainMenuScreen:
         self.screen.addstr(17, 4, "15) proxy        - set proxy settings...")
         self.screen.addstr(18, 4, "16) !sh          - escape to unix land...")
         self.screen.addstr(19, 4, "17) update       - git pull and restart")
-        self.screen.addstr(20, 4, "18) quit         - Exit webnuke")
-        self.screen.addstr(21, 4, "19) dns          - DNS tools...")
+        self.screen.addstr(20, 4, "18) dns          - DNS tools...")
+        self.screen.addstr(21, 4, "19) quit         - Exit webnuke")
         # pointy rocket ascii art with background stars
         greencolour = self.curses.color_pair(2)
         self.screen.addstr(7, 45, "        *        .     *", greencolour)


### PR DESCRIPTION
## Summary
- display DNS before quit on the main menu
- update command table to match order

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856806af1bc832eb7616b17e6c14200