### PR TITLE
Improve error logging in followme

### DIFF
--- a/libs/followme/followmemenu.py
+++ b/libs/followme/followmemenu.py
@@ -56,7 +56,7 @@ class FollowmeScreen:
             self.commands.start_new_instance()
             self.followme_count += 1
         except Exception:
-            self.logger.error("ERROR")
+            self.logger.error('Failed to start followme instance', exc_info=True)
             self.logger.log("EEE - error at start new followme instance")
             raise
 


### PR DESCRIPTION
## Summary
- update error log message when starting a Follow Me instance to include `exc_info`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685685a71020832e92cfa3292f7b4129