### PR TITLE
Enable HAR file import for XSS tools

### DIFF
--- a/console.py
+++ b/console.py
@@ -21,6 +21,11 @@ def main():
                 "Defaults to ./har_logs"
             ),
         )
+        parser.add_argument(
+            "--import-har",
+            dest="import_har",
+            help="Path to HAR file to load for XSS tools",
+        )
         parser.add_argument("--proxy-host", dest="proxy_host", help="Proxy server hostname or IP")
         parser.add_argument(
             "--proxy-port",
@@ -42,6 +47,7 @@ def main():
                     har_path=args.har_path,
                     proxy_host=args.proxy_host,
                     proxy_port=args.proxy_port,
+                    import_har=args.import_har,
                 )
                 if args.url:
                         mf.open_url(args.url)

--- a/libs/mainmenu/mainframe.py
+++ b/libs/mainmenu/mainframe.py
@@ -12,6 +12,7 @@ from libs.jsconsole.JSConsole import JSConsole
 from libs.spider.spiderscreen import SpiderScreen
 from libs.utils.javascriptinjector import JavascriptInjector
 from libs.utils import wait_for_enter, NetworkLogger
+from libs.utils.networklogger import load_har_file
 from libs.mainmenu.mainmenuscreen import MainMenuScreen
 from libs.followme.followmemenu import FollowmeScreen
 from libs.brutelogin.bruteloginmenu import BruteLoginScreen
@@ -29,7 +30,7 @@ import os
 import sys
 
 class mainframe:
-    def __init__(self, logger, headless=False, har_path=None, proxy_host='', proxy_port=0):
+    def __init__(self, logger, headless=False, har_path=None, proxy_host='', proxy_port=0, import_har=None):
         self.debug = True
         self.headless = headless
         self.har_path = har_path
@@ -42,6 +43,9 @@ class mainframe:
         self.logger = logger
         self.jsinjector = JavascriptInjector()
         self.network_logger = None
+        self.import_har = []
+        if import_har:
+            self.import_har = load_har_file(import_har, logger)
         atexit.register(self.curses_util.close_screen)
         # load plugin javascript
         self.plugins = [JSConsoleScript(self.jsinjector), JavascriptScript(self.jsinjector), HTMLToolsScript(self.jsinjector), AngularCustomJavascript(self.jsinjector)]
@@ -181,6 +185,7 @@ class mainframe:
                 self.curses_util,
                 self.logger,
                 self.network_logger,
+                self.import_har,
             ).show()
 
         def csrf_cmd(args):

--- a/libs/xss/xsscommands.py
+++ b/libs/xss/xsscommands.py
@@ -5,21 +5,22 @@ from libs.utils.logger import FileLogger
 from libs.utils import wait_for_enter
 
 class XSSCommands:
-    def __init__(self, webdriver, logger=None, network_logger=None):
+    def __init__(self, webdriver, logger=None, network_logger=None, imported_har=None):
         self.version = 2.0
         self.driver = webdriver
         self.logger = logger or FileLogger()
         self.network_logger = network_logger
+        self.imported_har = imported_har or []
 
     def _get_network_har(self):
         """Return HAR data from the attached network logger if available."""
-        if not self.network_logger:
-            return []
-        try:
-            return self.network_logger.get_har()
-        except Exception as exc:
-            self.logger.error(f"Error retrieving network HAR: {exc}")
-            return []
+        har = list(self.imported_har)
+        if self.network_logger:
+            try:
+                har.extend(self.network_logger.get_har())
+            except Exception as exc:
+                self.logger.error(f"Error retrieving network HAR: {exc}")
+        return har
 
     def _load_url_with_retry(self, url, delay: int = 2) -> None:
         """Load a URL retrying on network related errors."""

--- a/libs/xss/xssmenu.py
+++ b/libs/xss/xssmenu.py
@@ -5,13 +5,13 @@ from libs.utils import MenuHelper
 from libs.xss.xsscommands import XSSCommands
 
 class XSSScreen:
-    def __init__(self, screen, webdriver, curses_util, logger, network_logger=None):
+    def __init__(self, screen, webdriver, curses_util, logger, network_logger=None, imported_har=None):
         self.version = 2.0
         self.screen = screen
         self.driver = webdriver
         self.curses_util = curses_util
         self.logger = logger
-        self.commands = XSSCommands(self.driver, self.logger, network_logger)
+        self.commands = XSSCommands(self.driver, self.logger, network_logger, imported_har)
         
         
         

--- a/tests/test_mainframe.py
+++ b/tests/test_mainframe.py
@@ -2,6 +2,7 @@ import unittest
 import atexit
 import os
 import json
+import tempfile
 from libs.mainmenu.mainframe import mainframe
 from libs.utils.networklogger import NetworkLogger
 
@@ -42,8 +43,8 @@ class DummyDriver:
 class MainframeHistoryTests(unittest.TestCase):
     def setUp(self):
         class TestMainframe(mainframe):
-            def __init__(self_inner, logger):
-                super().__init__(logger)
+            def __init__(self_inner, logger, import_har=None):
+                super().__init__(logger, import_har=import_har)
                 atexit.unregister(self_inner.curses_util.close_screen)
 
             def create_browser_instance(self_inner):
@@ -104,6 +105,16 @@ class MainframeHistoryTests(unittest.TestCase):
         files = os.listdir('har_out')
         os.remove(os.path.join('har_out', files[0]))
         os.rmdir('har_out')
+
+    def test_import_har_loaded(self):
+        data = [{"url": "http://import.com", "status": 200}]
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tf:
+            json.dump(data, tf)
+            path = tf.name
+        mf = self.mf.__class__(DummyLogger(), import_har=path)
+        atexit.unregister(mf.curses_util.close_screen)
+        self.assertEqual(mf.import_har, data)
+        os.remove(path)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_xss.py
+++ b/tests/test_xss.py
@@ -131,6 +131,27 @@ class ReflectedParamTests(unittest.TestCase):
         cmds.find_reflected_params("TESTVAL")
         self.assertNotIn('Reflected parameter found', ''.join(logger.records))
 
+    @patch('libs.xss.xsscommands.wait_for_enter')
+    @patch('libs.xss.xsscommands.time.sleep')
+    def test_find_reflected_params_uses_imported_har(self, _sleep, _wait):
+        driver = DummyDriver()
+
+        class Logger:
+            def __init__(self):
+                self.records = []
+
+            def log(self, text):
+                self.records.append(text)
+
+            error = log
+            debug = log
+
+        logger = Logger()
+        har = [{"url": "http://example.com/api?fromhar=1", "status": 200}]
+        cmds = XSSCommands(driver, logger, imported_har=har)
+        cmds.find_reflected_params("VAL")
+        self.assertTrue(any("fromhar=VAL" in url for url in driver.visited))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- support parsing HAR files via new `load_har_file` helper
- load HAR entries in `mainframe` using `load_har_file`
- test that imported HAR entries feed into reflected parameter search

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68568653e69c832e8ebe190fd1a0b345