### PR TITLE
Add nmap SSL scan for DNS history

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Detect technologies in use not by parsing files or applying regex to file names 
 - Builtin browser functions are highlighted in the Javascript shell
 - DNS history shows IP owner
 - DNS history saved to dns_history/<domain>_<timestamp>.txt
+- Nmap SSL certificate scan for historical IPs with results saved to dns_history
 
 
 ## JSCONSOLE


### PR DESCRIPTION
## Summary
- run `nmap -sT -p 443 --script ssl-cert` on historical DNS IPs
- store the nmap output to individual files
- test that the scan is executed and results are saved
- document DNS history nmap scanning

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685adf4ee1bc832ea4b2a1e99df1296c