### PR TITLE
Skip Cloudflare IPs in DNS history nmap

### DIFF
--- a/libs/dns/dnscommands.py
+++ b/libs/dns/dnscommands.py
@@ -112,7 +112,7 @@ class DNSCommands:
                     line = f"{last_seen}: {ip} - {owner}"
                     self.logger.log(line)
                     results.append(line)
-                    ips.append(ip)
+                    ips.append((ip, owner))
             if results:
                 history_dir = os.path.join(os.getcwd(), "dns_history")
                 os.makedirs(history_dir, exist_ok=True)
@@ -125,7 +125,12 @@ class DNSCommands:
                     self.logger.log(f"Saved DNS history to {path}")
 
                     # run nmap for each IP and save output
-                    for ip in ips:
+                    for ip, owner in ips:
+                        if "cloudflare" in owner.lower():
+                            self.logger.log(
+                                f"Skipping nmap scan for Cloudflare IP {ip}"
+                            )
+                            continue
                         try:
                             proc = subprocess.run(
                                 [

--- a/tests/test_dnscommands.py
+++ b/tests/test_dnscommands.py
@@ -36,7 +36,8 @@ class DNSHistoryTests(unittest.TestCase):
         html = """
             <table>
             <tr><th>IP Address</th><th>Location</th><th>Owner</th><th>Last Seen</th></tr>
-            <tr><td>1.1.1.1</td><td>US</td><td>Cloudflare</td><td>2024-01-01</td></tr>
+            <tr><td>1.1.1.1</td><td>US</td><td>Cloudflare, Inc</td><td>2024-01-01</td></tr>
+            <tr><td>2.2.2.2</td><td>US</td><td>OtherCorp</td><td>2024-01-02</td></tr>
             </table>
         """
 
@@ -64,13 +65,14 @@ class DNSHistoryTests(unittest.TestCase):
                 path = os.path.join("dns_history", hist_file)
                 with open(path, "r", encoding="utf-8") as f:
                     data = f.read()
-                self.assertIn("2024-01-01: 1.1.1.1 - Cloudflare", data)
+                self.assertIn("2024-01-01: 1.1.1.1 - Cloudflare, Inc", data)
+                self.assertIn("2024-01-02: 2.2.2.2 - OtherCorp", data)
                 nmap_path = os.path.join("dns_history", nmap_file)
                 with open(nmap_path, "r", encoding="utf-8") as f:
                     nmap_data = f.read()
                 self.assertIn("nmap output", nmap_data)
-                mock_run.assert_called_with(
-                    ["nmap", "-sT", "-p", "443", "--script", "ssl-cert", "1.1.1.1"],
+                mock_run.assert_called_once_with(
+                    ["nmap", "-sT", "-p", "443", "--script", "ssl-cert", "2.2.2.2"],
                     capture_output=True,
                     text=True,
                     timeout=30,


### PR DESCRIPTION
## Summary
- skip nmap scan for Cloudflare-owned IPs when parsing DNS history
- update tests for the new exclusion logic

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ae1cb41f0832e9701a82d70603dce