### PR TITLE
Extend nmap scan timeout

### DIFF
--- a/libs/dns/dnscommands.py
+++ b/libs/dns/dnscommands.py
@@ -149,7 +149,7 @@ class DNSCommands:
                                 ],
                                 capture_output=True,
                                 text=True,
-                                timeout=30,
+                                timeout=300,
                             )
                             output = proc.stdout.strip()
                             self.logger.log(output)

--- a/tests/test_dnscommands.py
+++ b/tests/test_dnscommands.py
@@ -81,7 +81,7 @@ class DNSHistoryTests(unittest.TestCase):
                 self.assertEqual(cmd[9:], ["--min-parallelism", "10"])
                 self.assertEqual(called_kwargs["capture_output"], True)
                 self.assertEqual(called_kwargs["text"], True)
-                self.assertEqual(called_kwargs["timeout"], 30)
+                self.assertEqual(called_kwargs["timeout"], 300)
             finally:
                 os.chdir(cwd)
 


### PR DESCRIPTION
## Summary
- scan historical IP addresses longer with nmap
- adjust dnscommands unit test for new timeout

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ae9b1bda8832e9a6d554e7a6b8ce8