### PR TITLE
Add nmap domain summary

### DIFF
--- a/libs/dns/dnscommands.py
+++ b/libs/dns/dnscommands.py
@@ -178,6 +178,13 @@ class DNSCommands:
                                 self.logger.log("Highlighted nmap results:")
                                 for m in matches:
                                     self.logger.log(f"* {m}")
+
+                                # summarize entries that explicitly contain our domain
+                                domain_matches = [m for m in matches if domain.lower() in m.lower()]
+                                if domain_matches:
+                                    self.logger.log("Nmap domain summary:")
+                                    for dm in domain_matches:
+                                        self.logger.log(f"* {dm}")
                         except Exception as exc:
                             self.logger.error(f"Error running nmap: {exc}")
                 except Exception as exc:

--- a/tests/test_dnscommands.py
+++ b/tests/test_dnscommands.py
@@ -82,6 +82,8 @@ class DNSHistoryTests(unittest.TestCase):
                 self.assertEqual(called_kwargs["capture_output"], True)
                 self.assertEqual(called_kwargs["text"], True)
                 self.assertEqual(called_kwargs["timeout"], 300)
+                # domain summary should not be logged since nmap output lacks the domain
+                self.assertFalse(any("Nmap domain summary:" in r for r in logger.records))
             finally:
                 os.chdir(cwd)
 
@@ -121,6 +123,8 @@ class HighlightTests(unittest.TestCase):
                 self.assertIn("Highlighted nmap results:", logger.records)
                 self.assertTrue(any("foo.test.co.uk" in r for r in logger.records))
                 self.assertTrue(any("3.3.3.3" in r for r in logger.records))
+                self.assertIn("Nmap domain summary:", logger.records)
+                self.assertTrue(any("3.3.3.3" in r and "foo.test.co.uk" in r for r in logger.records))
             finally:
                 os.chdir(cwd)
 


### PR DESCRIPTION
## Summary
- output a short summary for lines with the current domain in nmap results
- verify summary logging in dns command tests

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685afd062ad8832ebab5cde8e76ee026