### PR TITLE
Fix followme proxy port and logging

### DIFF
--- a/libs/followme/followmecommands.py
+++ b/libs/followme/followmecommands.py
@@ -50,10 +50,10 @@ class FollowmeCommands:
     def create_browser_instance(self):
         self.webdriver_util = WebDriverUtil()
         self.webdriver_util.setDebug(self.debug)
-        if self.proxy_host != '' and int(self.proxy_port) != 0:
-            return self.webdriver_util.getDriverWithProxySupport(self.proxy_host, int(self.proxy_port))
-        else:
-            return self.webdriver_util.getDriver(self.logger)
+        port = int(self.proxy_port) if str(self.proxy_port).isdigit() else 0
+        if self.proxy_host and port:
+            return self.webdriver_util.getDriverWithProxySupport(self.proxy_host, port)
+        return self.webdriver_util.getDriver(self.logger)
 
     def linkbrowsers(self, maindriver, followmedriver):
         while self.run_thread:

--- a/libs/followme/followmemenu.py
+++ b/libs/followme/followmemenu.py
@@ -55,8 +55,8 @@ class FollowmeScreen:
         try:
             self.commands.start_new_instance()
             self.followme_count += 1
-        except Exception:
-            self.logger.error('Failed to start followme instance', exc_info=True)
+        except Exception as e:
+            self.logger.error(f'Failed to start followme instance: {e}')
             self.logger.log("EEE - error at start new followme instance")
             raise
 

--- a/tests/test_followme.py
+++ b/tests/test_followme.py
@@ -60,6 +60,15 @@ class FollowmeCommandsTests(unittest.TestCase):
         self.assertTrue(browser.quit_called)
         mock_thread.join.assert_called_once()
 
+    @patch('libs.followme.followmecommands.WebDriverUtil.getDriverWithProxySupport')
+    @patch('libs.followme.followmecommands.WebDriverUtil.getDriver')
+    def test_create_browser_instance_no_proxy_when_port_none(self, mock_get_driver, mock_get_proxy_driver):
+        self.cmds.proxy_host = 'localhost'
+        self.cmds.proxy_port = None
+        self.cmds.create_browser_instance()
+        mock_get_driver.assert_called_once_with(self.logger)
+        mock_get_proxy_driver.assert_not_called()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- handle `None` proxy port in followme
- adjust followme menu logging
- test handling of `None` proxy port

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c1a91a774832e964aa0d0ec95864e