### PR TITLE
Fix MX provider detection for multi-level TLDs

### DIFF
--- a/libs/quickdetect/MXEmailUtil.py
+++ b/libs/quickdetect/MXEmailUtil.py
@@ -4,15 +4,10 @@ class MXEmailUtil:
         self.logger = logger
 
     def _get_root_domain(self):
-        from urllib.parse import urlparse
-        parsed = urlparse(self.current_url)
-        domain = parsed.hostname
-        if not domain:
-            return None
-        parts = domain.split('.')
-        if len(parts) >= 2:
-            return '.'.join(parts[-2:])
-        return domain
+        """Return the registrable domain of the current URL."""
+        from libs.utils import get_root_domain
+
+        return get_root_domain(self.current_url)
 
     def _query_mx_records(self, domain):
         records = []

--- a/libs/quickdetect/O365Util.py
+++ b/libs/quickdetect/O365Util.py
@@ -37,17 +37,12 @@ class O365Util:
         return False
 
     def domain_uses_office365(self):
-        from urllib.parse import urlparse
+        from libs.utils import get_root_domain
         import subprocess
-        parsed = urlparse(self.current_url)
-        domain = parsed.hostname
-        if not domain:
+
+        root_domain = get_root_domain(self.current_url)
+        if not root_domain:
             return False
-        parts = domain.split('.')
-        if len(parts) >= 2:
-            root_domain = '.'.join(parts[-2:])
-        else:
-            root_domain = domain
         # try dnspython
         try:
             import dns.resolver  # type: ignore

--- a/libs/utils/__init__.py
+++ b/libs/utils/__init__.py
@@ -1,5 +1,6 @@
 from .menuhelper import MenuHelper
 from .networklogger import NetworkLogger
+from .domain import get_root_domain
 
 
 def wait_for_enter(prompt: str = "Press ENTER to return to menu.") -> None:

--- a/libs/utils/domain.py
+++ b/libs/utils/domain.py
@@ -1,0 +1,12 @@
+from urllib.parse import urlparse
+import tldextract
+
+
+def get_root_domain(url: str) -> str | None:
+    """Return the registrable domain for a URL."""
+    parsed = urlparse(url)
+    if not parsed.hostname:
+        return None
+    ext = tldextract.extract(parsed.hostname)
+    return ext.registered_domain or parsed.hostname
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
   "ipwhois",
   "dnspython",
   "beautifulsoup4",
+  "tldextract",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests
 ipwhois
 dnspython
 beautifulsoup4
+tldextract

--- a/tests/test_mxemailutil.py
+++ b/tests/test_mxemailutil.py
@@ -1,0 +1,48 @@
+import unittest
+from unittest.mock import patch
+
+from libs.quickdetect.MXEmailUtil import MXEmailUtil
+from libs.quickdetect.O365Util import O365Util
+
+
+class DummyLogger:
+    def log(self, *_):
+        pass
+    debug = log
+    error = log
+
+
+class MXEmailUtilTests(unittest.TestCase):
+    def test_provider_detects_outlook_multilevel_tld(self):
+        util = MXEmailUtil("https://www.example.co.uk", DummyLogger())
+        captured = {}
+
+        def fake_query(domain):
+            captured['domain'] = domain
+            return ["example-co-uk.mail.protection.outlook.com"]
+
+        util._query_mx_records = fake_query
+        provider = util.get_provider()
+        self.assertEqual(provider, "Office 365")
+        self.assertEqual(captured['domain'], "example.co.uk")
+
+
+class O365UtilTests(unittest.TestCase):
+    def test_domain_uses_office365_multilevel_tld(self):
+        class DummyDriver:
+            pass
+
+        util = O365Util(DummyDriver(), "https://www.example.co.uk", DummyLogger())
+
+        class Ans:
+            def __init__(self, val):
+                self.exchange = val
+
+        with patch('dns.resolver.resolve', return_value=[Ans('example-co-uk.mail.protection.outlook.com')]) as res, \
+             patch('subprocess.check_output', return_value=""):
+            self.assertTrue(util.domain_uses_office365())
+            self.assertEqual(res.call_args[0][0], "example.co.uk")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- handle multi-level TLDs when looking up MX records
- expose `get_root_domain` utility
- detect Office365 for domains such as `example.co.uk`
- add tests for MXEmailUtil and O365Util
- add `tldextract` dependency

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest tests/test_mxemailutil.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685c1de74b9c832e8dd5842ad8c2b96c